### PR TITLE
New Feature: Portal Networks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -376,3 +376,5 @@ FodyWeavers.xsd
 
 # Don't ignore the Docs/SolutionDir contents
 !**Docs/[Ss]olution[Dd]ir/**
+.idea
+*.DotSettings

--- a/XPortal/CustomNetworks.cs
+++ b/XPortal/CustomNetworks.cs
@@ -1,0 +1,617 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using BepInEx;
+using XPortal.RPC;
+
+namespace XPortal
+{
+    /// <summary>Configured portal networks (ids 1–15). Id 0 is normal Global.</summary>
+    internal static class CustomNetworks
+    {
+        internal const int MinId = 1;
+        internal const int MaxId = 15;
+
+        internal const string ConfigFileName = "xportal_networks.json";
+
+        private static readonly UTF8Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+        private static readonly Dictionary<long, string> ActiveById = new Dictionary<long, string>();
+
+        /// <summary>Extracts <c>id</c> / <c>name</c> pairs from the JSON (keys must appear as <c>"id"</c> then <c>"name"</c> per entry).</summary>
+        private static readonly Regex NetworkEntryRegex = new Regex(
+            @"""id""\s*:\s*(\d+)\s*,\s*""name""\s*:\s*""((?:[^""\\]|\\.)*)""",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+        private static FileSystemWatcher _watcher;
+        private static readonly object ReloadGate = new object();
+        private static readonly object ReloadTimerLock = new object();
+        private static SynchronizationContext _mainThreadContext;
+        private static global::System.Threading.Timer _reloadCoalesceTimer;
+        private const int CoalesceDelayMs = 400;
+
+        /// <summary>Fired when the active network list changes.</summary>
+        internal static event Action ListChanged;
+
+        #region Registry (client + server)
+
+        internal static void ResetSession()
+        {
+            lock (ActiveById)
+            {
+                ActiveById.Clear();
+            }
+        }
+
+        internal static void ServerSetFromParsed(Dictionary<long, string> parsed)
+        {
+            lock (ActiveById)
+            {
+                ActiveById.Clear();
+                foreach (var kv in parsed.OrderBy(k => k.Key))
+                {
+                    ActiveById[kv.Key] = kv.Value;
+                }
+            }
+        }
+
+        internal static void ApplyFromServer(ZPackage pkg)
+        {
+            var n = pkg.ReadInt();
+            lock (ActiveById)
+            {
+                ActiveById.Clear();
+                for (var i = 0; i < n; i++)
+                {
+                    var id = pkg.ReadLong();
+                    var name = pkg.ReadString();
+                    if (id < MinId || id > MaxId || string.IsNullOrEmpty(name))
+                    {
+                        continue;
+                    }
+
+                    ActiveById[id] = name;
+                }
+            }
+
+            ListChanged?.Invoke();
+        }
+
+        internal static ZPackage PackForServer()
+        {
+            List<KeyValuePair<long, string>> snapshot;
+            lock (ActiveById)
+            {
+                snapshot = ActiveById.OrderBy(k => k.Key).ToList();
+            }
+
+            var pkg = new ZPackage();
+            pkg.Write(snapshot.Count);
+            foreach (var kv in snapshot)
+            {
+                pkg.Write(kv.Key);
+                pkg.Write(kv.Value);
+            }
+
+            return pkg;
+        }
+
+        internal static bool IsActiveId(long id)
+        {
+            if (id < MinId || id > MaxId)
+            {
+                return false;
+            }
+
+            lock (ActiveById)
+            {
+                return ActiveById.ContainsKey(id);
+            }
+        }
+
+        internal static bool TryGetDisplayName(long id, out string displayName)
+        {
+            lock (ActiveById)
+            {
+                return ActiveById.TryGetValue(id, out displayName);
+            }
+        }
+
+        internal static List<long> GetSortedActiveIds()
+        {
+            lock (ActiveById)
+            {
+                return ActiveById.Keys.OrderBy(k => k).ToList();
+            }
+        }
+
+        /// <summary>True if id is in the 1–15 configured range.</summary>
+        internal static bool IsReservedIdRange(long id)
+        {
+            return id >= MinId && id <= MaxId;
+        }
+
+        internal static void MigrateInvalidNetworks()
+        {
+            if (!Environment.IsServer)
+            {
+                return;
+            }
+
+            foreach (var p in KnownPortalsManager.Instance.GetList().ToList())
+            {
+                if (!IsReservedIdRange(p.NetworkOwnerPlayerId))
+                {
+                    continue;
+                }
+
+                if (IsActiveId(p.NetworkOwnerPlayerId))
+                {
+                    continue;
+                }
+
+                p.NetworkOwnerPlayerId = 0L;
+                p.NetworkOwnerDisplayName = string.Empty;
+                KnownPortalsManager.Instance.AddOrUpdate(p);
+                ZdoTools.UpdateFromKnownPortal(state: p);
+                SendToClient.SyncPortal(p);
+                Log.Info($"Migrated portal `{p.Id}` to Global network (network id was removed or invalid).");
+            }
+        }
+
+        internal static void NotifyListChangedLocal()
+        {
+            ListChanged?.Invoke();
+        }
+
+        #endregion
+
+        #region Server: file + watcher
+
+        internal static void InitializeServer()
+        {
+            if (!Environment.IsServer)
+            {
+                return;
+            }
+
+            _mainThreadContext = SynchronizationContext.Current;
+
+            EnsureDefaultConfigExists();
+            ReloadFromDiskAndBroadcast(isInitial: true);
+
+            var dir = Path.GetDirectoryName(GetConfigFilePath());
+            if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir))
+            {
+                return;
+            }
+
+            try
+            {
+                _watcher?.Dispose();
+                _watcher = new FileSystemWatcher(dir)
+                {
+                    Filter = ConfigFileName,
+                    NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size | NotifyFilters.FileName,
+                };
+                _watcher.Changed += OnWatcherEvent;
+                _watcher.Created += OnWatcherEvent;
+                _watcher.Renamed += OnWatcherRenamed;
+                _watcher.EnableRaisingEvents = true;
+                Log.Debug($"Watching `{dir}` for `{ConfigFileName}` changes.");
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"Could not watch custom networks config folder: {ex.Message}");
+            }
+        }
+
+        internal static void ShutdownServer()
+        {
+            lock (ReloadTimerLock)
+            {
+                _reloadCoalesceTimer?.Dispose();
+                _reloadCoalesceTimer = null;
+            }
+
+            _watcher?.Dispose();
+            _watcher = null;
+        }
+
+        private static string GetConfigFilePath()
+        {
+            return Path.Combine(Paths.ConfigPath, Mod.Info.Name, ConfigFileName);
+        }
+
+        /// <summary>Default JSON baked into the assembly (see csproj EmbeddedResource).</summary>
+        private static string ReadEmbeddedTemplate()
+        {
+            try
+            {
+                var asm = Assembly.GetExecutingAssembly();
+                foreach (var resName in asm.GetManifestResourceNames())
+                {
+                    if (!resName.EndsWith(ConfigFileName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    using (var s = asm.GetManifestResourceStream(resName))
+                    {
+                        if (s == null)
+                        {
+                            continue;
+                        }
+
+                        using (var r = new StreamReader(s, Utf8NoBom))
+                        {
+                            return r.ReadToEnd();
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"Failed to read embedded `{ConfigFileName}` from assembly: {ex.GetType().Name}: {ex.Message}");
+            }
+
+            return null;
+        }
+
+        private static void EnsureDefaultConfigExists()
+        {
+            var path = GetConfigFilePath();
+            try
+            {
+                var dir = Path.GetDirectoryName(path);
+                if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
+
+                if (File.Exists(path))
+                {
+                    return;
+                }
+
+                var templateText = ReadEmbeddedTemplate();
+                if (!string.IsNullOrEmpty(templateText))
+                {
+                    File.WriteAllText(path, templateText, Utf8NoBom);
+                    Log.Info($"Created `{path}` from embedded `{ConfigFileName}`.");
+                    return;
+                }
+
+                Log.Error($"Embedded default template `{ConfigFileName}` not found; cannot create `{path}`.");
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"Could not create default custom networks file: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Reads the config file from disk. Returns false if the file does not exist (not an error).
+        /// Sets <paramref name="readError"/> true when the file exists but could not be read.
+        /// </summary>
+        private static bool TryReadConfigFile(out string text, out bool readError)
+        {
+            text = null;
+            readError = false;
+            var path = GetConfigFilePath();
+            try
+            {
+                if (!File.Exists(path))
+                {
+                    return false;
+                }
+
+                text = File.ReadAllText(path, Utf8NoBom);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                readError = File.Exists(path);
+                Log.Error($"Could not read custom networks file `{path}`: {ex.GetType().Name}: {ex.Message}");
+                return false;
+            }
+        }
+
+        private static Dictionary<long, string> ParseConfigJson(string raw)
+        {
+            var result = new Dictionary<long, string>();
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return result;
+            }
+
+            raw = StripUtf8Bom(raw.Trim());
+
+            var invalidId = 0;
+            var emptyOrSanitizedName = 0;
+            var duplicateId = 0;
+            var decodeErrors = 0;
+
+            try
+            {
+                foreach (Match m in NetworkEntryRegex.Matches(raw))
+                {
+                    if (!int.TryParse(m.Groups[1].Value, out var id) || id < MinId || id > MaxId)
+                    {
+                        invalidId++;
+                        continue;
+                    }
+
+                    string name;
+                    try
+                    {
+                        name = UnescapeJsonString(m.Groups[2].Value);
+                    }
+                    catch (Exception ex)
+                    {
+                        decodeErrors++;
+                        Log.Warning($"Custom networks JSON: skipped entry for id {id} (invalid escape sequence in name): {ex.GetType().Name}: {ex.Message}");
+                        continue;
+                    }
+
+                    if (string.IsNullOrWhiteSpace(name))
+                    {
+                        emptyOrSanitizedName++;
+                        continue;
+                    }
+
+                    name = PortalNetwork.SanitizeNetworkOwnerDisplayName(name);
+                    if (string.IsNullOrEmpty(name))
+                    {
+                        emptyOrSanitizedName++;
+                        continue;
+                    }
+
+                    var idLong = (long)id;
+                    if (result.ContainsKey(idLong))
+                    {
+                        duplicateId++;
+                        continue;
+                    }
+
+                    result.Add(idLong, name);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"Custom networks JSON: unexpected failure while scanning `{ConfigFileName}`: {ex.GetType().Name}: {ex.Message}");
+                return result;
+            }
+
+            if (invalidId > 0)
+            {
+                Log.Warning($"Custom networks JSON: skipped {invalidId} {(invalidId == 1 ? "entry" : "entries")} with id outside {MinId}–{MaxId}.");
+            }
+
+            if (emptyOrSanitizedName > 0)
+            {
+                Log.Warning($"Custom networks JSON: skipped {emptyOrSanitizedName} {(emptyOrSanitizedName == 1 ? "entry" : "entries")} with empty or invalid name after sanitization.");
+            }
+
+            if (duplicateId > 0)
+            {
+                Log.Warning($"Custom networks JSON: skipped {duplicateId} duplicate id {(duplicateId == 1 ? "entry" : "entries")}.");
+            }
+
+            // Non-trivial content but nothing usable — likely malformed structure, wrong key order, or bad syntax.
+            if (result.Count == 0 && raw.Length > 2)
+            {
+                Log.Warning(
+                    $"Custom networks JSON: no valid entries found in `{ConfigFileName}`. Expected patterns like \"id\": 1, \"name\": \"...\" with ids in {MinId}–{MaxId}. Check the file format.");
+            }
+
+            return result;
+        }
+
+        private static string StripUtf8Bom(string s)
+        {
+            if (string.IsNullOrEmpty(s) || s[0] != '\uFEFF')
+            {
+                return s;
+            }
+
+            return s.Substring(1);
+        }
+
+        private static string UnescapeJsonString(string s)
+        {
+            if (string.IsNullOrEmpty(s) || s.IndexOf('\\') < 0)
+            {
+                return s;
+            }
+
+            try
+            {
+                var sb = new StringBuilder(s.Length);
+                for (var i = 0; i < s.Length; i++)
+                {
+                    if (s[i] != '\\' || i + 1 >= s.Length)
+                    {
+                        sb.Append(s[i]);
+                        continue;
+                    }
+
+                    i++;
+                    switch (s[i])
+                    {
+                        case '"':
+                            sb.Append('"');
+                            break;
+                        case '\\':
+                            sb.Append('\\');
+                            break;
+                        case '/':
+                            sb.Append('/');
+                            break;
+                        case 'b':
+                            sb.Append('\b');
+                            break;
+                        case 'f':
+                            sb.Append('\f');
+                            break;
+                        case 'n':
+                            sb.Append('\n');
+                            break;
+                        case 'r':
+                            sb.Append('\r');
+                            break;
+                        case 't':
+                            sb.Append('\t');
+                            break;
+                        case 'u':
+                            if (i + 4 < s.Length
+                                && uint.TryParse(s.Substring(i + 1, 4), System.Globalization.NumberStyles.HexNumber, null, out var code))
+                            {
+                                sb.Append((char)code);
+                                i += 4;
+                            }
+                            else
+                            {
+                                sb.Append('u');
+                            }
+
+                            break;
+                        default:
+                            sb.Append(s[i]);
+                            break;
+                    }
+                }
+
+                return sb.ToString();
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException("Failed to unescape JSON string fragment.", ex);
+            }
+        }
+
+        private static bool IsOurConfigFile(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return false;
+            }
+
+            return name.Equals(ConfigFileName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static void OnWatcherRenamed(object sender, RenamedEventArgs e)
+        {
+            if (IsOurConfigFile(e.Name))
+            {
+                QueueReload();
+            }
+        }
+
+        private static void OnWatcherEvent(object sender, FileSystemEventArgs e)
+        {
+            if (IsOurConfigFile(e.Name))
+            {
+                QueueReload();
+            }
+        }
+
+        private static void QueueReload()
+        {
+            lock (ReloadTimerLock)
+            {
+                _reloadCoalesceTimer?.Dispose();
+                _reloadCoalesceTimer = new global::System.Threading.Timer(
+                    _ => OnCoalesceTimerFired(),
+                    null,
+                    CoalesceDelayMs,
+                    Timeout.Infinite);
+            }
+        }
+
+        private static void OnCoalesceTimerFired()
+        {
+            try
+            {
+                var ctx = _mainThreadContext;
+                if (ctx != null)
+                {
+                    ctx.Post(
+                        _ =>
+                        {
+                            try
+                            {
+                                ReloadFromDiskAndBroadcast(isInitial: false);
+                            }
+                            catch (Exception ex)
+                            {
+                                Log.Error($"Custom networks reload failed: {ex.Message}");
+                            }
+                        },
+                        null);
+                }
+                else
+                {
+                    Log.Warning("No synchronization context; reloading custom networks on the watcher thread (may be unsafe).");
+                    ReloadFromDiskAndBroadcast(isInitial: false);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"Custom networks reload scheduling failed: {ex.Message}");
+            }
+        }
+
+        private static void ReloadFromDiskAndBroadcast(bool isInitial)
+        {
+            lock (ReloadGate)
+            {
+                if (!TryReadConfigFile(out var text, out var readError))
+                {
+                    if (!readError)
+                    {
+                        EnsureDefaultConfigExists();
+                    }
+
+                    if (!TryReadConfigFile(out text, out readError) || text == null)
+                    {
+                        if (readError)
+                        {
+                            Log.Error(
+                                $"Keeping the previous custom network list; fix `{GetConfigFilePath()}` and save, or restart the server after correcting the file.");
+                            return;
+                        }
+
+                        text = string.Empty;
+                    }
+                }
+
+                var parsed = ParseConfigJson(text ?? string.Empty);
+                ServerSetFromParsed(parsed);
+                MigrateInvalidNetworks();
+
+                if (!isInitial)
+                {
+                    SendToClient.BroadcastCustomNetworks(PackForServer());
+                }
+
+                if (!isInitial)
+                {
+                    Log.Info("Custom networks file reloaded and pushed to clients.");
+                }
+
+                if (!Environment.IsHeadless)
+                {
+                    NotifyListChangedLocal();
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/XPortal/KnownPortal.cs
+++ b/XPortal/KnownPortal.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.IO;
+using UnityEngine;
 using XPortal.Extension;
 
 namespace XPortal
@@ -11,6 +12,16 @@ namespace XPortal
         public ZDOID Target { get; set; }
         public Vector3 Location { get; set; }
         public string Colour { get; set; }
+
+        /// <summary>
+        /// 0 = Global network. Non-zero = personal network owned by this player id (matches Piece creator for that portal).
+        /// </summary>
+        public long NetworkOwnerPlayerId { get; set; }
+
+        /// <summary>
+        /// Label for the personal network owner; stored on the portal ZDO and replicated to clients.
+        /// </summary>
+        public string NetworkOwnerDisplayName { get; set; }
 
         public bool IsDefaultPortal
         {
@@ -28,6 +39,8 @@ namespace XPortal
             PreviousId = ZDOID.None;
             Target = KnownPortalsManager.Instance.FindDefaultPortal();
             Colour = PortalColour.GetPortalColour(id);
+            NetworkOwnerPlayerId = 0L;
+            NetworkOwnerDisplayName = string.Empty;
         }
 
         public KnownPortal(ZDOID id, Vector3 location) : this(id)
@@ -43,6 +56,21 @@ namespace XPortal
             PreviousId = pkg.ReadZDOID();
             Target = pkg.ReadZDOID();
             Colour = pkg.ReadString();
+            NetworkOwnerPlayerId = pkg.ReadLong();
+            NetworkOwnerDisplayName = ReadOptionalString(pkg);
+        }
+
+        /// <summary>Reads the packed network owner display name, or empty if the package has no more data.</summary>
+        private static string ReadOptionalString(ZPackage pkg)
+        {
+            try
+            {
+                return pkg.ReadString();
+            }
+            catch (EndOfStreamException)
+            {
+                return string.Empty;
+            }
         }
 
         public string GetFriendlyName()
@@ -87,6 +115,8 @@ namespace XPortal
             pkg.Write(PreviousId);
             pkg.Write(Target);
             pkg.Write(Colour);
+            pkg.Write(NetworkOwnerPlayerId);
+            pkg.Write(NetworkOwnerDisplayName ?? string.Empty);
             return pkg;
         }
 
@@ -97,7 +127,12 @@ namespace XPortal
 
         public override string ToString()
         {
-            return $"{{ Id: `{Id}`, Name; `{GetFriendlyName()}`, Location: `{Location}`, Target: `{Target}` (`{GetFriendlyTargetName()}`), Colour: `{Colour}` }}";
+            return $"{{ Id: `{Id}`, Name; `{GetFriendlyName()}`, Location: `{Location}`, NetworkOwner: `{NetworkOwnerPlayerId}` (`{NetworkOwnerDisplayName}`), Target: `{Target}` (`{GetFriendlyTargetName()}`), Colour: `{Colour}` }}";
+        }
+
+        public bool IsGlobalNetwork()
+        {
+            return NetworkOwnerPlayerId == 0L;
         }
     }
 }

--- a/XPortal/KnownPortal.cs
+++ b/XPortal/KnownPortal.cs
@@ -23,6 +23,11 @@ namespace XPortal
         /// </summary>
         public string NetworkOwnerDisplayName { get; set; }
 
+        /// <summary>
+        /// Private portals are listed only for their owner (and excluded from others' destination lists); they cannot use the global network.
+        /// </summary>
+        public bool IsPrivate { get; set; }
+
         public bool IsDefaultPortal
         {
             get
@@ -41,6 +46,7 @@ namespace XPortal
             Colour = PortalColour.GetPortalColour(id);
             NetworkOwnerPlayerId = 0L;
             NetworkOwnerDisplayName = string.Empty;
+            IsPrivate = false;
         }
 
         public KnownPortal(ZDOID id, Vector3 location) : this(id)
@@ -58,6 +64,7 @@ namespace XPortal
             Colour = pkg.ReadString();
             NetworkOwnerPlayerId = pkg.ReadLong();
             NetworkOwnerDisplayName = ReadOptionalString(pkg);
+            IsPrivate = ReadOptionalBool(pkg);
         }
 
         /// <summary>Reads the packed network owner display name, or empty if the package has no more data.</summary>
@@ -70,6 +77,18 @@ namespace XPortal
             catch (EndOfStreamException)
             {
                 return string.Empty;
+            }
+        }
+
+        private static bool ReadOptionalBool(ZPackage pkg)
+        {
+            try
+            {
+                return pkg.ReadBool();
+            }
+            catch (EndOfStreamException)
+            {
+                return false;
             }
         }
 
@@ -117,6 +136,7 @@ namespace XPortal
             pkg.Write(Colour);
             pkg.Write(NetworkOwnerPlayerId);
             pkg.Write(NetworkOwnerDisplayName ?? string.Empty);
+            pkg.Write(IsPrivate);
             return pkg;
         }
 
@@ -127,7 +147,7 @@ namespace XPortal
 
         public override string ToString()
         {
-            return $"{{ Id: `{Id}`, Name; `{GetFriendlyName()}`, Location: `{Location}`, NetworkOwner: `{NetworkOwnerPlayerId}` (`{NetworkOwnerDisplayName}`), Target: `{Target}` (`{GetFriendlyTargetName()}`), Colour: `{Colour}` }}";
+            return $"{{ Id: `{Id}`, Name; `{GetFriendlyName()}`, Location: `{Location}`, NetworkOwner: `{NetworkOwnerPlayerId}` (`{NetworkOwnerDisplayName}`), Private: `{IsPrivate}`, Target: `{Target}` (`{GetFriendlyTargetName()}`), Colour: `{Colour}` }}";
         }
 
         public bool IsGlobalNetwork()

--- a/XPortal/KnownPortal.cs
+++ b/XPortal/KnownPortal.cs
@@ -13,19 +13,13 @@ namespace XPortal
         public Vector3 Location { get; set; }
         public string Colour { get; set; }
 
-        /// <summary>
-        /// 0 = Global network. Non-zero = personal network owned by this player id (matches Piece creator for that portal).
-        /// </summary>
+        /// <summary>0 = Global, 1–15 = custom globals, else personal network id.</summary>
         public long NetworkOwnerPlayerId { get; set; }
 
-        /// <summary>
-        /// Label for the personal network owner; stored on the portal ZDO and replicated to clients.
-        /// </summary>
+        /// <summary>Network owner label stored on the portal ZDO.</summary>
         public string NetworkOwnerDisplayName { get; set; }
 
-        /// <summary>
-        /// Private portals are listed only for their owner (and excluded from others' destination lists); they cannot use the global network.
-        /// </summary>
+        /// <summary>Private portals are owner-only in lists and behave as personal network.</summary>
         public bool IsPrivate { get; set; }
 
         public bool IsDefaultPortal
@@ -49,9 +43,11 @@ namespace XPortal
             IsPrivate = false;
         }
 
+        /// <summary>Used when a portal is first placed (or hover placeholder). Privacy default comes from config (<see cref="XPortalConfig.ConfigSettings.DefaultPrivatePortal"/>).</summary>
         public KnownPortal(ZDOID id, Vector3 location) : this(id)
         {
             Location = location;
+            IsPrivate = XPortalConfig.Instance.Local.DefaultPrivatePortal.Value;
         }
 
         public KnownPortal(ZPackage pkg)

--- a/XPortal/KnownPortal.cs
+++ b/XPortal/KnownPortal.cs
@@ -43,7 +43,7 @@ namespace XPortal
             IsPrivate = false;
         }
 
-        /// <summary>Used when a portal is first placed (or hover placeholder). Privacy default comes from config (<see cref="XPortalConfig.ConfigSettings.DefaultPrivatePortal"/>).</summary>
+        /// <summary>New or hover placeholder portal; privacy default from config.</summary>
         public KnownPortal(ZDOID id, Vector3 location) : this(id)
         {
             Location = location;

--- a/XPortal/KnownPortalsManager.cs
+++ b/XPortal/KnownPortalsManager.cs
@@ -51,9 +51,7 @@ namespace XPortal
             return knownPortals.Where(p => p.Value.PreviousId == previousId).Select(kvp => kvp.Value).FirstOrDefault();
         }
 
-        /// <summary>
-        /// Returns <see cref="KnownPortal.NetworkOwnerDisplayName"/> from any portal on that network, or null if none are set.
-        /// </summary>
+        /// <summary>Returns any stored network display name for that network id, or null.</summary>
         public string GetNetworkOwnerDisplayNameForPlayerId(long networkOwnerPlayerId)
         {
             if (networkOwnerPlayerId == 0L)

--- a/XPortal/KnownPortalsManager.cs
+++ b/XPortal/KnownPortalsManager.cs
@@ -40,12 +40,42 @@ namespace XPortal
         {
             return knownPortals[id];
         }
+
+        public bool TryGetValue(ZDOID id, out KnownPortal portal)
+        {
+            return knownPortals.TryGetValue(id, out portal);
+        }
         
         public KnownPortal GetKnownPortalByPreviousId(ZDOID previousId)
         {
             return knownPortals.Where(p => p.Value.PreviousId == previousId).Select(kvp => kvp.Value).FirstOrDefault();
         }
 
+        /// <summary>
+        /// Returns <see cref="KnownPortal.NetworkOwnerDisplayName"/> from any portal on that network, or null if none are set.
+        /// </summary>
+        public string GetNetworkOwnerDisplayNameForPlayerId(long networkOwnerPlayerId)
+        {
+            if (networkOwnerPlayerId == 0L)
+            {
+                return null;
+            }
+
+            foreach (var p in knownPortals.Values)
+            {
+                if (p.NetworkOwnerPlayerId != networkOwnerPlayerId)
+                {
+                    continue;
+                }
+
+                if (!string.IsNullOrEmpty(p.NetworkOwnerDisplayName))
+                {
+                    return p.NetworkOwnerDisplayName;
+                }
+            }
+
+            return null;
+        }
 
         public List<KnownPortal> GetList()
         {
@@ -122,6 +152,8 @@ namespace XPortal
                     Location = portalZDO.GetPosition(),
                     PreviousId = portalZDO.GetZDOID(XPortal.Key_PreviousId),
                     Target = portalZDO.GetZDOID(XPortal.Key_TargetId),
+                    NetworkOwnerPlayerId = ZdoTools.GetNetworkOwnerPlayerId(portalZDO),
+                    NetworkOwnerDisplayName = ZdoTools.GetNetworkOwnerDisplayName(portalZDO),
                 };
 
                 portalsWithZdos.Add(knownPortal);
@@ -141,7 +173,7 @@ namespace XPortal
             var portalsInPackage = new List<KnownPortal>();
             if (count > 0)
             {
-                for (int i = 0; i < count; i++)
+                for (var i = 0; i < count; i++)
                 {
                     var portalPkg = pkg.ReadPackage();
                     var portal = new KnownPortal(portalPkg);
@@ -191,7 +223,7 @@ namespace XPortal
 
         public ZDOID FindDefaultPortal()
         {
-            Vector3 defaultLocation = XPortalConfig.Instance.Local.DefaultPortal.Value.Round();
+            var defaultLocation = XPortalConfig.Instance.Local.DefaultPortal.Value.Round();
             var defaultPortal = FindByLocation(defaultLocation);
 
             if (defaultPortal == null)
@@ -210,7 +242,7 @@ namespace XPortal
                 return;
             }
 
-            foreach (KnownPortal p in knownPortals.Values)
+            foreach (var p in knownPortals.Values)
             {
                 Log.Debug($" {p}");
             }

--- a/XPortal/KnownPortalsManager.cs
+++ b/XPortal/KnownPortalsManager.cs
@@ -154,6 +154,7 @@ namespace XPortal
                     Target = portalZDO.GetZDOID(XPortal.Key_TargetId),
                     NetworkOwnerPlayerId = ZdoTools.GetNetworkOwnerPlayerId(portalZDO),
                     NetworkOwnerDisplayName = ZdoTools.GetNetworkOwnerDisplayName(portalZDO),
+                    IsPrivate = ZdoTools.GetIsPrivate(portalZDO),
                 };
 
                 portalsWithZdos.Add(knownPortal);

--- a/XPortal/NetPeerUtility.cs
+++ b/XPortal/NetPeerUtility.cs
@@ -1,0 +1,73 @@
+namespace XPortal
+{
+    /// <summary>
+    /// Peer player id resolution and admin checks for portal network changes.
+    /// </summary>
+    internal static class NetPeerUtility
+    {
+        /// <summary>
+        /// Player id for the peer's character, or 0 if unavailable.
+        /// </summary>
+        internal static long GetPeerPlayerId(long peerId)
+        {
+            if (ZNet.instance == null || ZDOMan.instance == null)
+            {
+                return 0L;
+            }
+
+            var peer = ZNet.instance.GetPeer(peerId);
+            if (peer == null)
+            {
+                // Server Host is not in m_peers; routed RPC sender id is ZNet.GetUID().
+                if (ZNet.instance.IsServer() && peerId == ZNet.GetUID())
+                {
+                    if (Player.m_localPlayer != null)
+                    {
+                        return Player.m_localPlayer.GetPlayerID();
+                    }
+
+                    return Game.instance != null ? Game.instance.GetPlayerProfile().GetPlayerID() : 0L;
+                }
+
+                return 0L;
+            }
+
+            if (peer.m_characterID.IsNone())
+            {
+                return 0L;
+            }
+
+            var characterZdo = ZDOMan.instance.GetZDO(peer.m_characterID);
+            if (characterZdo == null)
+            {
+                return 0L;
+            }
+
+            return characterZdo.GetLong(ZDOVars.s_playerID);
+        }
+
+        /// <summary>
+        /// True if the peer is a server admin and may change portal network assignment.
+        /// </summary>
+        internal static bool IsPeerPrivilegedForPortalNetwork(long peerId)
+        {
+            if (ZNet.instance == null)
+            {
+                return false;
+            }
+
+            var peer = ZNet.instance.GetPeer(peerId);
+            if (peer == null)
+            {
+                if (ZNet.instance.IsServer() && peerId == ZNet.GetUID())
+                {
+                    return ZNet.instance.LocalPlayerIsAdminOrHost();
+                }
+
+                return false;
+            }
+
+            return ZNet.instance.IsAdmin(peer.m_socket.GetHostName());
+        }
+    }
+}

--- a/XPortal/Patches/Dropdown.cs
+++ b/XPortal/Patches/Dropdown.cs
@@ -33,7 +33,10 @@ namespace XPortal.Patches
         {
             if (__instance.name.Equals(PortalConfigurationPanel.GO_DESTINATIONDROPDOWN))
             {
+                PortalConfigurationPanel.ClearListScroll();
                 PortalConfigurationPanel.Instance.DropdownExpanded = true;
+                PortalConfigurationPanel.ApplyListScroll(__instance);
+                PortalConfigurationPanel.QueueListScroll(__instance);
             }
         }
     }
@@ -46,7 +49,27 @@ namespace XPortal.Patches
             if (__instance.name.Equals(PortalConfigurationPanel.GO_DESTINATIONDROPDOWN))
             {
                 PortalConfigurationPanel.Instance.DropdownExpanded = false;
+                PortalConfigurationPanel.ClearListScroll();
             }
+        }
+    }
+
+    [HarmonyPatch(typeof(Dropdown), "set_value")]
+    static class Dropdown_SetValue
+    {
+        static void Postfix(Dropdown __instance)
+        {
+            if (!__instance.name.Equals(PortalConfigurationPanel.GO_DESTINATIONDROPDOWN))
+            {
+                return;
+            }
+
+            if (PortalConfigurationPanel.Instance == null || !PortalConfigurationPanel.Instance.DropdownExpanded)
+            {
+                return;
+            }
+
+            PortalConfigurationPanel.ApplyListScroll(__instance);
         }
     }
 }

--- a/XPortal/Patches/Dropdown.cs
+++ b/XPortal/Patches/Dropdown.cs
@@ -9,20 +9,26 @@ namespace XPortal.Patches
     {
         static bool Prefix(Dropdown __instance)
         {
-            if (PortalConfigurationPanel.Instance != null && __instance.name.Equals(PortalConfigurationPanel.GO_DESTINATIONDROPDOWN))
+            if (PortalConfigurationPanel.Instance == null || !PortalConfigurationPanel.IsManagedDropdown(__instance))
             {
-                if (PortalConfigurationPanel.Instance.DropdownExpanded)
-                {
-                    __instance.Hide();
-                }
-                else
-                {
-                    __instance.Show();
-                }
+                return true;
+            }
+
+            PortalConfigurationPanel panel = PortalConfigurationPanel.Instance;
+
+            if (panel.ExpandedDropdown == __instance)
+            {
+                __instance.Hide();
                 return false;
             }
 
-            return true;
+            if (panel.ExpandedDropdown != null && panel.ExpandedDropdown != __instance)
+            {
+                panel.ExpandedDropdown.Hide();
+            }
+
+            __instance.Show();
+            return false;
         }
     }
 
@@ -31,13 +37,15 @@ namespace XPortal.Patches
     {
         static void Postfix(Dropdown __instance)
         {
-            if (__instance.name.Equals(PortalConfigurationPanel.GO_DESTINATIONDROPDOWN))
+            if (!PortalConfigurationPanel.IsManagedDropdownName(__instance.name))
             {
-                PortalConfigurationPanel.ClearListScroll();
-                PortalConfigurationPanel.Instance.DropdownExpanded = true;
-                PortalConfigurationPanel.ApplyListScroll(__instance);
-                PortalConfigurationPanel.QueueListScroll(__instance);
+                return;
             }
+
+            PortalConfigurationPanel.ClearListScroll();
+            PortalConfigurationPanel.Instance.SetExpandedDropdown(__instance);
+            PortalConfigurationPanel.ApplyListScroll(__instance);
+            PortalConfigurationPanel.QueueListScroll(__instance);
         }
     }
 
@@ -46,11 +54,13 @@ namespace XPortal.Patches
     {
         static void Postfix(Dropdown __instance)
         {
-            if (__instance.name.Equals(PortalConfigurationPanel.GO_DESTINATIONDROPDOWN))
+            if (!PortalConfigurationPanel.IsManagedDropdownName(__instance.name))
             {
-                PortalConfigurationPanel.Instance.DropdownExpanded = false;
-                PortalConfigurationPanel.ClearListScroll();
+                return;
             }
+
+            PortalConfigurationPanel.Instance.ClearExpandedDropdownIf(__instance);
+            PortalConfigurationPanel.ClearListScroll();
         }
     }
 
@@ -59,12 +69,13 @@ namespace XPortal.Patches
     {
         static void Postfix(Dropdown __instance)
         {
-            if (!__instance.name.Equals(PortalConfigurationPanel.GO_DESTINATIONDROPDOWN))
+            if (!PortalConfigurationPanel.IsManagedDropdownName(__instance.name))
             {
                 return;
             }
 
-            if (PortalConfigurationPanel.Instance == null || !PortalConfigurationPanel.Instance.DropdownExpanded)
+            PortalConfigurationPanel panel = PortalConfigurationPanel.Instance;
+            if (panel == null || panel.ExpandedDropdown != __instance)
             {
                 return;
             }

--- a/XPortal/Patches/Patcher.cs
+++ b/XPortal/Patches/Patcher.cs
@@ -14,12 +14,30 @@ namespace XPortal.Patches
             patcher.PatchAll(typeof(Game_Start));
             patcher.PatchAll(typeof(Game_ConnectPortals));
             patcher.PatchAll(typeof(Game_ConnectPortalsCoroutine));
+            //patcher.PatchAll(typeof(Player_PlacePiece));
             patcher.PatchAll(typeof(TeleportWorld_GetHoverText));
             patcher.PatchAll(typeof(TextInput_RequestText));
             patcher.PatchAll(typeof(WearNTear_Destroy));
             patcher.PatchAll(typeof(ZDOMan_ConnectPortals));
             patcher.PatchAll(typeof(ZNet_RPC_PeerInfo_Postfix));
+
+            // Temporarily disable this work-around and revert back to the old method
+
             patcher.PatchAll(typeof(WearNTear_OnPlaced));
+
+            //var playerPlacePiecePatched =
+            //    Harmony.GetAllPatchedMethods().Where(m => m.DeclaringType.Name.Equals("Player") && m.Name.Equals("PlacePiece")).Any();
+
+            //if (!playerPlacePiecePatched)
+            //{
+            //    Log.Debug("Patching WearNTear.OnPlaced, yay!");
+            //    patcher.PatchAll(typeof(WearNTear_OnPlaced));
+            //}
+            //else
+            //{
+            //    Log.Debug("Patching Piece.SetCreator, boo!");
+            //    patcher.PatchAll(typeof(Piece_SetCreator));
+            //}
         }
 
         public static void Unpatch() => patcher?.UnpatchSelf();

--- a/XPortal/Patches/Patcher.cs
+++ b/XPortal/Patches/Patcher.cs
@@ -10,6 +10,7 @@ namespace XPortal.Patches
             patcher.PatchAll(typeof(Dropdown_OnSubmit));
             patcher.PatchAll(typeof(Dropdown_Show));
             patcher.PatchAll(typeof(Dropdown_Hide));
+            patcher.PatchAll(typeof(Dropdown_SetValue));
             patcher.PatchAll(typeof(Game_Awake));
             patcher.PatchAll(typeof(Game_Start));
             patcher.PatchAll(typeof(Game_ConnectPortals));

--- a/XPortal/Patches/Patcher.cs
+++ b/XPortal/Patches/Patcher.cs
@@ -21,6 +21,7 @@ namespace XPortal.Patches
             patcher.PatchAll(typeof(TeleportWorld_UpdatePortal_Transpiler));
             patcher.PatchAll(typeof(TextInput_RequestText));
             patcher.PatchAll(typeof(WearNTear_Destroy));
+            patcher.PatchAll(typeof(Piece_CanBeRemoved));
             patcher.PatchAll(typeof(ZDOMan_ConnectPortals));
             patcher.PatchAll(typeof(ZNet_RPC_PeerInfo_Postfix));
 

--- a/XPortal/Patches/Patcher.cs
+++ b/XPortal/Patches/Patcher.cs
@@ -16,6 +16,8 @@ namespace XPortal.Patches
             patcher.PatchAll(typeof(Game_ConnectPortalsCoroutine));
             //patcher.PatchAll(typeof(Player_PlacePiece));
             patcher.PatchAll(typeof(TeleportWorld_GetHoverText));
+            patcher.PatchAll(typeof(TeleportWorld_Teleport_PrivateDestination));
+            patcher.PatchAll(typeof(TeleportWorld_UpdatePortal_Transpiler));
             patcher.PatchAll(typeof(TextInput_RequestText));
             patcher.PatchAll(typeof(WearNTear_Destroy));
             patcher.PatchAll(typeof(ZDOMan_ConnectPortals));

--- a/XPortal/Patches/Patcher.cs
+++ b/XPortal/Patches/Patcher.cs
@@ -14,31 +14,12 @@ namespace XPortal.Patches
             patcher.PatchAll(typeof(Game_Start));
             patcher.PatchAll(typeof(Game_ConnectPortals));
             patcher.PatchAll(typeof(Game_ConnectPortalsCoroutine));
-            //patcher.PatchAll(typeof(Player_PlacePiece));
             patcher.PatchAll(typeof(TeleportWorld_GetHoverText));
             patcher.PatchAll(typeof(TextInput_RequestText));
             patcher.PatchAll(typeof(WearNTear_Destroy));
             patcher.PatchAll(typeof(ZDOMan_ConnectPortals));
-
-
-
-            // Temporarily disable this work-around and revert back to the old method
-
+            patcher.PatchAll(typeof(ZNet_RPC_PeerInfo_Postfix));
             patcher.PatchAll(typeof(WearNTear_OnPlaced));
-
-            //var playerPlacePiecePatched =
-            //    Harmony.GetAllPatchedMethods().Where(m => m.DeclaringType.Name.Equals("Player") && m.Name.Equals("PlacePiece")).Any();
-
-            //if (!playerPlacePiecePatched)
-            //{
-            //    Log.Debug("Patching WearNTear.OnPlaced, yay!");
-            //    patcher.PatchAll(typeof(WearNTear_OnPlaced));
-            //}
-            //else
-            //{
-            //    Log.Debug("Patching Piece.SetCreator, boo!");
-            //    patcher.PatchAll(typeof(Piece_SetCreator));
-            //}
         }
 
         public static void Unpatch() => patcher?.UnpatchSelf();

--- a/XPortal/Patches/Piece.cs
+++ b/XPortal/Patches/Piece.cs
@@ -41,4 +41,32 @@ namespace XPortal.Patches
             }
         }
     }
+
+    /// <summary>Portal hammer removal when the server enables restrictions.</summary>
+    [HarmonyPatch(typeof(Piece), nameof(Piece.CanBeRemoved))]
+    static class Piece_CanBeRemoved
+    {
+        static void Postfix(Piece __instance, ref bool __result)
+        {
+            if (!__instance || string.IsNullOrEmpty(__instance.m_name) || !__instance.m_name.Contains("$piece_portal"))
+            {
+                return;
+            }
+
+            if (!XPortalConfig.Instance.Server.RestrictPortalRemoval)
+            {
+                return;
+            }
+
+            __result = CanRemovePortal(__instance);
+        }
+
+        static bool CanRemovePortal(Piece piece)
+        {
+            if (ZNet.instance != null && ZNet.instance.LocalPlayerIsAdminOrHost())
+                return true;
+
+            return piece.IsCreator();
+        }
+    }
 }

--- a/XPortal/Patches/Piece.cs
+++ b/XPortal/Patches/Piece.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using XPortal.RPC;
 
 namespace XPortal.Patches
 {
@@ -63,7 +64,7 @@ namespace XPortal.Patches
 
         static bool CanRemovePortal(Piece piece)
         {
-            if (ZNet.instance != null && ZNet.instance.LocalPlayerIsAdminOrHost())
+            if (ZNet.instance.LocalPlayerIsAdminOrHost() || XPortalAdminSync.IsLocalPortalNetworkAdmin())
                 return true;
 
             return piece.IsCreator();

--- a/XPortal/Patches/TeleportWorld.cs
+++ b/XPortal/Patches/TeleportWorld.cs
@@ -1,8 +1,6 @@
 ﻿using HarmonyLib;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Reflection.Emit;
 using JetBrains.Annotations;
 
@@ -44,11 +42,7 @@ namespace XPortal.Patches
         }
     }
 
-    /// <summary>
-    /// Blocks using a portal when its connection target is another player's private portal (client-side).
-    /// Vanilla <see cref="TeleportWorld.Teleport"/> then checks <see cref="Humanoid.IsTeleportable"/> for inventory
-    /// (ores, etc.); that call has no portal context, so destination privacy is handled here instead.
-    /// </summary>
+    /// <summary>Blocks teleport when the destination is another player’s private portal (client).</summary>
     [HarmonyPatch(typeof(TeleportWorld), nameof(TeleportWorld.Teleport))]
     static class TeleportWorld_Teleport_PrivateDestination
     {

--- a/XPortal/Patches/TeleportWorld.cs
+++ b/XPortal/Patches/TeleportWorld.cs
@@ -1,4 +1,10 @@
 ﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using JetBrains.Annotations;
 
 namespace XPortal.Patches
 {
@@ -35,6 +41,108 @@ namespace XPortal.Patches
 
             // Don't run the original method
             return false;
+        }
+    }
+
+    /// <summary>
+    /// Blocks using a portal when its connection target is another player's private portal (client-side).
+    /// Vanilla <see cref="TeleportWorld.Teleport"/> then checks <see cref="Humanoid.IsTeleportable"/> for inventory
+    /// (ores, etc.); that call has no portal context, so destination privacy is handled here instead.
+    /// </summary>
+    [HarmonyPatch(typeof(TeleportWorld), nameof(TeleportWorld.Teleport))]
+    static class TeleportWorld_Teleport_PrivateDestination
+    {
+        static bool Prefix(Player player, ZNetView ___m_nview)
+        {
+            if (Environment.ShuttingDown)
+            {
+                return true;
+            }
+
+            if (player == null || Player.m_localPlayer == null || player != Player.m_localPlayer)
+            {
+                return true;
+            }
+
+            if (___m_nview == null || !___m_nview.IsValid())
+            {
+                return true;
+            }
+
+            var portalZdo = ___m_nview.GetZDO();
+            if (portalZdo == null)
+            {
+                return true;
+            }
+
+            if (!XPortal.LocalPrivateUseBlocked(portalZdo.m_uid))
+            {
+                return true;
+            }
+
+            // Skip original Teleport (no extra message — see design notes).
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Injects into flag2 after vanilla computes closestPlayer.IsTeleportable() || m_allowAllItems, so
+    /// private-destination gating runs in the same pass as inventory gating (no duplicate proximity / target work).
+    /// Using a transpiler here to reduce the amount of logic per frame used.
+    /// </summary>
+    [HarmonyPatch(typeof(TeleportWorld), "UpdatePortal")]
+    static class TeleportWorld_UpdatePortal_Transpiler
+    {
+
+        [UsedImplicitly]
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            var instrs = instructions.ToList();
+            var counter = 0;
+
+            CodeInstruction LogMessage(CodeInstruction instruction)
+            {
+                Log.Debug($"IL_{counter}: Opcode: {instruction.opcode} Operand: {instruction.operand}");
+                return instruction;
+            }
+            
+            // The function we want to run
+            // Passing flag2 into the function so that we can escape out of it, if the flag is already false.
+            // flag2 = XPortal.PrivateUseBlockedForPortal(this, closestPlayer, flag2)
+            
+            var mTargetFound = AccessTools.DeclaredField(typeof(TeleportWorld), nameof(TeleportWorld.m_target_found));
+
+            for (int i = 0; i < instrs.Count; ++i)
+            {
+                // In IL code, we are looking for the store loc.2 opcode that is right before the m_target_found.SetActive() virtual call.
+                // So we are matching on the 3 opcodes of stloc_2, ldarg_0, and lfld (where the field = mTargetFound)
+                // If matched, we are loading the variables needed and then calling Xportal.IsUseablePortal() and setting that output to flag2/loc.2.
+                if (i > 5 && instrs[i].opcode == OpCodes.Stloc_2 && instrs[i+1].opcode == OpCodes.Ldarg_0 && instrs[i+2].opcode == OpCodes.Ldfld && instrs[i+2].operand.Equals(mTargetFound))
+                {
+                    // Return original stloc.2 - flag2
+                    yield return LogMessage(instrs[i]);
+                    
+                    // Load Ldarg_0 (this)
+                    yield return LogMessage(new CodeInstruction(OpCodes.Ldarg_0));
+                    
+                    // load loc.0 (closest player)
+                    yield return LogMessage(new CodeInstruction(OpCodes.Ldloc_0));
+                    
+                    // Load loc.2 (flag2)
+                    yield return LogMessage(new CodeInstruction(OpCodes.Ldloc_2));
+                    
+                    // Call Method
+                    yield return LogMessage(new CodeInstruction(OpCodes.Call, AccessTools.DeclaredMethod(typeof(XPortal), nameof(XPortal.IsUsablePortal))));
+                    
+                    // Set loc.2
+                    yield return LogMessage(new CodeInstruction(OpCodes.Stloc_2));
+                }
+                else
+                {
+                    yield return LogMessage(instrs[i]);
+                    counter++;
+                }
+            }
         }
     }
 }

--- a/XPortal/Patches/TeleportWorld.cs
+++ b/XPortal/Patches/TeleportWorld.cs
@@ -13,6 +13,7 @@ namespace XPortal.Patches
             if (Environment.ShuttingDown)
             {
                 Log.Debug("Shutting down, ignoring hover");
+                __result = string.Empty;
 
                 // Don't run the original method
                 return false;
@@ -27,7 +28,7 @@ namespace XPortal.Patches
                 return false;
             }
 
-            ZDO portalZDO = ___m_nview.GetZDO();
+            var portalZDO = ___m_nview.GetZDO();
             var portalId = portalZDO.m_uid;
             var location = portalZDO.GetPosition();
             XPortal.OnPrePortalHover(out __result, portalId, location);

--- a/XPortal/Patches/TextInput.cs
+++ b/XPortal/Patches/TextInput.cs
@@ -14,7 +14,7 @@ namespace XPortal.Patches
             if (sign is TeleportWorld teleportWorld)
             {
                 // Request the XPortal UI here instead of the vanilla "set tag" window
-                XPortal.OnPortalRequestText(teleportWorld.m_nview.GetZDO().m_uid);
+                XPortal.OnPortalRequestText(teleportWorld);
 
                 // Don't run the original method at all
                 return false;

--- a/XPortal/Patches/ZNet.cs
+++ b/XPortal/Patches/ZNet.cs
@@ -1,0 +1,22 @@
+using HarmonyLib;
+using XPortal.RPC;
+
+namespace XPortal.Patches
+{
+    /// <summary>
+    /// After peer handshake on clients, request portal network admin status from the server.
+    /// </summary>
+    [HarmonyPatch(typeof(ZNet), "RPC_PeerInfo")]
+    internal static class ZNet_RPC_PeerInfo_Postfix
+    {
+        private static void Postfix(ZNet __instance)
+        {
+            if (__instance == null || __instance.IsServer())
+            {
+                return;
+            }
+
+            XPortalAdminSync.RequestFromServerIfNeeded();
+        }
+    }
+}

--- a/XPortal/PortalNetwork.cs
+++ b/XPortal/PortalNetwork.cs
@@ -1,0 +1,175 @@
+namespace XPortal
+{
+    internal static class PortalNetwork
+    {
+        /// <summary>Trims and limits length for a stored network owner display name.</summary>
+        internal static string SanitizeNetworkOwnerDisplayName(string raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return string.Empty;
+            }
+
+            var t = raw.Trim();
+            const int maxLen = 64;
+            if (t.Length > maxLen)
+            {
+                t = t.Substring(0, maxLen);
+            }
+
+            return t;
+        }
+
+        internal static string FormatNetworkLabel(long ownerPlayerId)
+        {
+            if (ownerPlayerId == 0L)
+            {
+                return Localization.instance.Localize("$hud_xportal_network_global");
+            }
+
+            var networkWord = Localization.instance.Localize("$hud_xportal_network_suffix");
+
+            var cached = KnownPortalsManager.Instance.GetNetworkOwnerDisplayNameForPlayerId(ownerPlayerId);
+            if (!string.IsNullOrEmpty(cached))
+            {
+                return $"{cached.Trim()} {networkWord}";
+            }
+
+            var name = ResolvePlayerDisplayName(ownerPlayerId).Trim();
+            if (string.IsNullOrEmpty(name))
+            {
+                return networkWord;
+            }
+
+            return $"{name} {networkWord}";
+        }
+
+        private static string ResolvePlayerDisplayName(long ownerPlayerId)
+        {
+            if (Player.m_localPlayer != null && Player.m_localPlayer.GetPlayerID() == ownerPlayerId)
+            {
+                return Player.m_localPlayer.GetPlayerName();
+            }
+
+            var onlinePlayer = Player.GetPlayer(ownerPlayerId);
+            if (onlinePlayer != null)
+            {
+                var fromPlayer = onlinePlayer.GetPlayerName();
+                if (!string.IsNullOrWhiteSpace(fromPlayer) && fromPlayer != "...")
+                {
+                    return fromPlayer;
+                }
+            }
+
+            var fromWorld = TryResolveByWorldState(ownerPlayerId);
+            if (!string.IsNullOrEmpty(fromWorld))
+            {
+                return fromWorld;
+            }
+
+            if (Game.instance != null && Game.instance.GetPlayerProfile().GetPlayerID() == ownerPlayerId)
+            {
+                return Game.instance.GetPlayerProfile().GetName();
+            }
+
+            return ownerPlayerId.ToString();
+        }
+
+        /// <summary>
+        /// Resolves a display name from character ZDOs, the ESC player list (including server-assigned names), then peers.
+        /// </summary>
+        internal static string TryResolveByWorldState(long ownerPlayerId)
+        {
+            if (ownerPlayerId == 0L || ZNet.instance == null || ZDOMan.instance == null)
+            {
+                return null;
+            }
+
+            foreach (var zdo in ZNet.instance.GetAllCharacterZDOS())
+            {
+                if (zdo == null || zdo.GetLong(ZDOVars.s_playerID) != ownerPlayerId)
+                {
+                    continue;
+                }
+
+                var n = zdo.GetString(ZDOVars.s_playerName, string.Empty);
+                if (IsUsablePlayerName(n))
+                {
+                    return n.Trim();
+                }
+            }
+
+            foreach (var info in ZNet.instance.GetPlayerList())
+            {
+                if (info.m_characterID.IsNone())
+                {
+                    continue;
+                }
+
+                var characterZdo = ZDOMan.instance.GetZDO(info.m_characterID);
+                if (characterZdo == null || characterZdo.GetLong(ZDOVars.s_playerID) != ownerPlayerId)
+                {
+                    continue;
+                }
+
+                if (!string.IsNullOrEmpty(info.m_serverAssignedDisplayName))
+                {
+                    return info.m_serverAssignedDisplayName.Trim();
+                }
+
+                if (!string.IsNullOrEmpty(info.m_name))
+                {
+                    return info.m_name.Trim();
+                }
+
+                if (!string.IsNullOrEmpty(info.m_userInfo.m_displayName))
+                {
+                    return info.m_userInfo.m_displayName.Trim();
+                }
+
+                var zdoName = characterZdo.GetString(ZDOVars.s_playerName, string.Empty);
+                if (IsUsablePlayerName(zdoName))
+                {
+                    return zdoName.Trim();
+                }
+            }
+
+            foreach (var peer in ZNet.instance.GetPeers())
+            {
+                if (peer.m_characterID.IsNone())
+                {
+                    continue;
+                }
+
+                var characterZdo = ZDOMan.instance.GetZDO(peer.m_characterID);
+                if (characterZdo == null || characterZdo.GetLong(ZDOVars.s_playerID) != ownerPlayerId)
+                {
+                    continue;
+                }
+
+                if (!string.IsNullOrEmpty(peer.m_playerName))
+                {
+                    return peer.m_playerName.Trim();
+                }
+            }
+
+            return null;
+        }
+
+        private static bool IsUsablePlayerName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return false;
+            }
+
+            // Default used by Player.GetPlayerName() when the ZDO has no name yet
+            if (name == "...")
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/XPortal/PortalNetwork.cs
+++ b/XPortal/PortalNetwork.cs
@@ -47,6 +47,15 @@ namespace XPortal
 
             var networkWord = Localization.instance.Localize("$hud_xportal_network_suffix");
 
+            // Portal ZDOs cache a display name for the network owner; that string can be stale or wrong
+            // (e.g. another character) while NetworkOwnerPlayerId is correct. For the local player's id,
+            // always use live resolution so the UI matches the character you are playing.
+            if (IsLocalPlayerNetworkId(ownerPlayerId))
+            {
+                var self = ResolvePlayerDisplayName(ownerPlayerId).Trim();
+                return $"{self} {networkWord}";
+            }
+
             var cached = KnownPortalsManager.Instance.GetNetworkOwnerDisplayNameForPlayerId(ownerPlayerId);
             if (!string.IsNullOrEmpty(cached))
             {
@@ -60,6 +69,16 @@ namespace XPortal
             }
 
             return $"{name} {networkWord}";
+        }
+
+        private static bool IsLocalPlayerNetworkId(long ownerPlayerId)
+        {
+            if (Player.m_localPlayer != null)
+            {
+                return Player.m_localPlayer.GetPlayerID() == ownerPlayerId;
+            }
+
+            return Game.instance != null && Game.instance.GetPlayerProfile().GetPlayerID() == ownerPlayerId;
         }
 
         private static string ResolvePlayerDisplayName(long ownerPlayerId)

--- a/XPortal/PortalNetwork.cs
+++ b/XPortal/PortalNetwork.cs
@@ -2,6 +2,9 @@ namespace XPortal
 {
     internal static class PortalNetwork
     {
+        /// <summary>Dropdown sentinel: "My Private Portals" bucket (not a real network owner id).</summary>
+        internal const long DestinationNetworkMyPrivateBucket = -1L;
+
         /// <summary>Trims and limits length for a stored network owner display name.</summary>
         internal static string SanitizeNetworkOwnerDisplayName(string raw)
         {
@@ -22,6 +25,11 @@ namespace XPortal
 
         internal static string FormatNetworkLabel(long ownerPlayerId)
         {
+            if (ownerPlayerId == DestinationNetworkMyPrivateBucket)
+            {
+                return Localization.instance.Localize("$hud_xportal_network_my_private");
+            }
+
             if (ownerPlayerId == 0L)
             {
                 return Localization.instance.Localize("$hud_xportal_network_global");

--- a/XPortal/PortalNetwork.cs
+++ b/XPortal/PortalNetwork.cs
@@ -35,6 +35,16 @@ namespace XPortal
                 return Localization.instance.Localize("$hud_xportal_network_global");
             }
 
+            if (ownerPlayerId >= CustomNetworks.MinId && ownerPlayerId <= CustomNetworks.MaxId)
+            {
+                if (CustomNetworks.TryGetDisplayName(ownerPlayerId, out var customName))
+                {
+                    return customName;
+                }
+
+                return ownerPlayerId.ToString();
+            }
+
             var networkWord = Localization.instance.Localize("$hud_xportal_network_suffix");
 
             var cached = KnownPortalsManager.Instance.GetNetworkOwnerDisplayNameForPlayerId(ownerPlayerId);

--- a/XPortal/QueuedAction.cs
+++ b/XPortal/QueuedAction.cs
@@ -52,7 +52,7 @@ namespace XPortal
             var processedActions = queuedActions.Where(kvp => kvp.Value.Delay < 0).ToList();
             foreach (var processedAction in processedActions)
             {
-                Log.Warning($"Cleaned up stale action {processedAction.Value.Action.Method.Name}");
+                Log.Debug($"Cleaned up stale action {processedAction.Value.Action.Method.Name}");
                 queuedActions.Remove(processedAction.Key);
             }
         }

--- a/XPortal/RPC/ClientEvents.cs
+++ b/XPortal/RPC/ClientEvents.cs
@@ -1,4 +1,6 @@
-﻿namespace XPortal.RPC.Client
+﻿using XPortal.RPC;
+
+namespace XPortal.RPC.Client
 {
     internal static class ClientEvents
     {
@@ -49,6 +51,21 @@
         {
             Log.Info("Received XPortal Config from server");
             XPortalConfig.Instance.ReceiveServerConfig(pkg);
+        }
+
+        /// <summary>
+        /// Server reply: whether this client is a server admin for portal network UI.
+        /// </summary>
+        internal static void RPC_AdminSync(long sender, ZPackage pkg)
+        {
+            if (Environment.IsServer)
+            {
+                return;
+            }
+
+            bool isAdmin = pkg.ReadBool();
+            XPortalAdminSync.ApplyServerReply(isAdmin);
+            Log.Debug($"Portal network admin UI allowed: {isAdmin}");
         }
     }
 }

--- a/XPortal/RPC/ClientEvents.cs
+++ b/XPortal/RPC/ClientEvents.cs
@@ -1,6 +1,4 @@
-﻿using XPortal.RPC;
-
-namespace XPortal.RPC.Client
+﻿namespace XPortal.RPC.Client
 {
     internal static class ClientEvents
     {
@@ -51,6 +49,12 @@ namespace XPortal.RPC.Client
         {
             Log.Info("Received XPortal Config from server");
             XPortalConfig.Instance.ReceiveServerConfig(pkg);
+        }
+
+        internal static void RPC_CustomNetworks(long sender, ZPackage pkg)
+        {
+            Log.Debug("Received custom networks from server");
+            CustomNetworks.ApplyFromServer(pkg);
         }
 
         /// <summary>

--- a/XPortal/RPC/RPCManager.cs
+++ b/XPortal/RPC/RPCManager.cs
@@ -9,6 +9,7 @@ namespace XPortal.RPC
         internal const string RPC_SYNCPORTAL = Mod.Info.Name + "_SyncPortal";
         internal const string RPC_RESYNC = Mod.Info.Name + "_Resync";
         internal const string RPC_CONFIG = Mod.Info.Name + "_Config";
+        internal const string RPC_CUSTOMNETWORKS = Mod.Info.Name + "_CustomNetworks";
         internal const string RPC_ADMINSYNC = Mod.Info.Name + "_AdminSync";
 
         // Client RPCs
@@ -16,6 +17,7 @@ namespace XPortal.RPC
         internal const string RPC_ADDORUPDATEREQUEST = Mod.Info.Name + "_AddOrUpdateRequest";
         internal const string RPC_REMOVEREQUEST = Mod.Info.Name + "_RemoveRequest";
         internal const string RPC_CONFIGREQUEST = Mod.Info.Name + "_ConfigRequest";
+        internal const string RPC_REQUESTCUSTOMNETWORKS = Mod.Info.Name + "_RequestCustomNetworks";
         internal const string RPC_REQUESTADMINSYNC = Mod.Info.Name + "_RequestAdminSync";
 
         // Client to client
@@ -31,6 +33,7 @@ namespace XPortal.RPC
             ZRoutedRpc.instance.Register(RPC_SYNCPORTAL, new Action<long, ZPackage>(Client.ClientEvents.RPC_SyncPortal));
             ZRoutedRpc.instance.Register(RPC_RESYNC, new Action<long, ZPackage, string>(Client.ClientEvents.RPC_Resync));
             ZRoutedRpc.instance.Register(RPC_CONFIG, new Action<long, ZPackage>(Client.ClientEvents.RPC_Config));
+            ZRoutedRpc.instance.Register(RPC_CUSTOMNETWORKS, new Action<long, ZPackage>(Client.ClientEvents.RPC_CustomNetworks));
             ZRoutedRpc.instance.Register(RPC_ADMINSYNC, new Action<long, ZPackage>(Client.ClientEvents.RPC_AdminSync));
 
             // Client RPCs
@@ -38,6 +41,7 @@ namespace XPortal.RPC
             ZRoutedRpc.instance.Register(RPC_ADDORUPDATEREQUEST, new Action<long, ZPackage>(Server.ServerEvents.RPC_AddOrUpdateRequest));
             ZRoutedRpc.instance.Register(RPC_REMOVEREQUEST, new Action<long, ZDOID>(Server.ServerEvents.RPC_RemoveRequest));
             ZRoutedRpc.instance.Register(RPC_CONFIGREQUEST, new Action<long>(Server.ServerEvents.RPC_ConfigRequest));
+            ZRoutedRpc.instance.Register(RPC_REQUESTCUSTOMNETWORKS, new Action<long>(Server.ServerEvents.RPC_RequestCustomNetworks));
             ZRoutedRpc.instance.Register(RPC_REQUESTADMINSYNC, new Action<long, ZPackage>(Server.ServerEvents.RPC_RequestAdminSync));
         }
     }

--- a/XPortal/RPC/RPCManager.cs
+++ b/XPortal/RPC/RPCManager.cs
@@ -9,12 +9,14 @@ namespace XPortal.RPC
         internal const string RPC_SYNCPORTAL = Mod.Info.Name + "_SyncPortal";
         internal const string RPC_RESYNC = Mod.Info.Name + "_Resync";
         internal const string RPC_CONFIG = Mod.Info.Name + "_Config";
+        internal const string RPC_ADMINSYNC = Mod.Info.Name + "_AdminSync";
 
         // Client RPCs
         internal const string RPC_SYNCREQUEST = Mod.Info.Name + "_SyncRequest";
         internal const string RPC_ADDORUPDATEREQUEST = Mod.Info.Name + "_AddOrUpdateRequest";
         internal const string RPC_REMOVEREQUEST = Mod.Info.Name + "_RemoveRequest";
         internal const string RPC_CONFIGREQUEST = Mod.Info.Name + "_ConfigRequest";
+        internal const string RPC_REQUESTADMINSYNC = Mod.Info.Name + "_RequestAdminSync";
 
         // Client to client
         internal const string RPC_CHATMESSAGE = "ChatMessage";
@@ -29,12 +31,14 @@ namespace XPortal.RPC
             ZRoutedRpc.instance.Register(RPC_SYNCPORTAL, new Action<long, ZPackage>(Client.ClientEvents.RPC_SyncPortal));
             ZRoutedRpc.instance.Register(RPC_RESYNC, new Action<long, ZPackage, string>(Client.ClientEvents.RPC_Resync));
             ZRoutedRpc.instance.Register(RPC_CONFIG, new Action<long, ZPackage>(Client.ClientEvents.RPC_Config));
+            ZRoutedRpc.instance.Register(RPC_ADMINSYNC, new Action<long, ZPackage>(Client.ClientEvents.RPC_AdminSync));
 
             // Client RPCs
             ZRoutedRpc.instance.Register(RPC_SYNCREQUEST, new Action<long, string>(Server.ServerEvents.RPC_SyncRequest));
             ZRoutedRpc.instance.Register(RPC_ADDORUPDATEREQUEST, new Action<long, ZPackage>(Server.ServerEvents.RPC_AddOrUpdateRequest));
             ZRoutedRpc.instance.Register(RPC_REMOVEREQUEST, new Action<long, ZDOID>(Server.ServerEvents.RPC_RemoveRequest));
             ZRoutedRpc.instance.Register(RPC_CONFIGREQUEST, new Action<long>(Server.ServerEvents.RPC_ConfigRequest));
+            ZRoutedRpc.instance.Register(RPC_REQUESTADMINSYNC, new Action<long, ZPackage>(Server.ServerEvents.RPC_RequestAdminSync));
         }
     }
 }

--- a/XPortal/RPC/SendToClient.cs
+++ b/XPortal/RPC/SendToClient.cs
@@ -60,6 +60,25 @@ namespace XPortal.RPC
             ZRoutedRpc.instance.InvokeRoutedRPC(clientPeerID, RPCManager.RPC_CONFIG, pkg);
         }
 
+        /// <summary>Sends the custom network list to one client.</summary>
+        public static void CustomNetworks(long clientPeerID, ZPackage pkg)
+        {
+            Log.Debug($"Sending custom networks to {clientPeerID}");
+            ZRoutedRpc.instance.InvokeRoutedRPC(clientPeerID, RPCManager.RPC_CUSTOMNETWORKS, pkg);
+        }
+
+        /// <summary>Sends the custom network list to all connected peers.</summary>
+        public static void BroadcastCustomNetworks(ZPackage pkg)
+        {
+            if (ZNet.instance == null || ZNet.instance.GetConnectedPeers().Count == 0)
+            {
+                return;
+            }
+
+            Log.Debug("Broadcasting custom networks to everybody");
+            ZRoutedRpc.instance.InvokeRoutedRPC(ZRoutedRpc.Everybody, RPCManager.RPC_CUSTOMNETWORKS, pkg);
+        }
+
         /// <summary>
         /// Send a ping to everyone
         /// </summary>

--- a/XPortal/RPC/SendToServer.cs
+++ b/XPortal/RPC/SendToServer.cs
@@ -42,5 +42,12 @@
             Log.Debug($"Asking server to send me the config");
             ZRoutedRpc.instance.InvokeRoutedRPC(Environment.ServerPeerId, RPCManager.RPC_CONFIGREQUEST);
         }
+
+        /// <summary>Ask the server for the custom network list.</summary>
+        public static void RequestCustomNetworks()
+        {
+            Log.Debug("Asking server for custom networks");
+            ZRoutedRpc.instance.InvokeRoutedRPC(Environment.ServerPeerId, RPCManager.RPC_REQUESTCUSTOMNETWORKS);
+        }
     }
 }

--- a/XPortal/RPC/ServerEvents.cs
+++ b/XPortal/RPC/ServerEvents.cs
@@ -1,4 +1,7 @@
-﻿namespace XPortal.RPC.Server
+﻿using XPortal;
+using XPortal.RPC;
+
+namespace XPortal.RPC.Server
 {
     internal static class ServerEvents
     {
@@ -31,9 +34,63 @@
             var portal = new KnownPortal(pkg);
             Log.Debug($"{sender} wants `{portal.Id}` to be added or updated");
 
+            var requesterPlayerId = NetPeerUtility.GetPeerPlayerId(sender);
+            var portalZdo = ZDOMan.instance.GetZDO(portal.Id);
+            if (portalZdo == null)
+            {
+                Log.Error($"Portal ZDO `{portal.Id}` not found for network validation");
+                return;
+            }
+
+            var pieceCreator = portalZdo.GetLong(ZDOVars.s_creator);
+            var requesterIsCreator = requesterPlayerId != 0L && requesterPlayerId == pieceCreator;
+            var requesterMayChangeNetwork = requesterIsCreator || NetPeerUtility.IsPeerPrivilegedForPortalNetwork(sender);
+
+            KnownPortalsManager.Instance.TryGetValue(portal.Id, out var existing);
+
+            if (!requesterMayChangeNetwork)
+            {
+                var authoritativeNetwork = existing != null
+                    ? existing.NetworkOwnerPlayerId
+                    : ZdoTools.GetNetworkOwnerPlayerId(portalZdo);
+                portal.NetworkOwnerPlayerId = authoritativeNetwork;
+                portal.NetworkOwnerDisplayName = existing != null
+                    ? existing.NetworkOwnerDisplayName
+                    : ZdoTools.GetNetworkOwnerDisplayName(portalZdo);
+            }
+            else
+            {
+                if (portal.NetworkOwnerPlayerId == 0L)
+                {
+                    portal.NetworkOwnerDisplayName = string.Empty;
+                }
+                else
+                {
+                    portal.NetworkOwnerPlayerId = pieceCreator;
+                    if (pieceCreator == 0L)
+                    {
+                        portal.NetworkOwnerDisplayName = string.Empty;
+                    }
+                    else if (requesterIsCreator)
+                    {
+                        var fromClient = PortalNetwork.SanitizeNetworkOwnerDisplayName(portal.NetworkOwnerDisplayName);
+                        portal.NetworkOwnerDisplayName = !string.IsNullOrEmpty(fromClient)
+                            ? fromClient
+                            : (PortalNetwork.TryResolveByWorldState(pieceCreator) ?? string.Empty);
+                    }
+                    else
+                    {
+                        portal.NetworkOwnerDisplayName = PortalNetwork.TryResolveByWorldState(pieceCreator)
+                            ?? existing?.NetworkOwnerDisplayName
+                            ?? ZdoTools.GetNetworkOwnerDisplayName(portalZdo)
+                            ?? string.Empty;
+                    }
+                }
+            }
+
             var updatedPortal = KnownPortalsManager.Instance.AddOrUpdate(portal);
 
-            Log.Info($"Setting portal tag `{updatedPortal.Name}` and target `{updatedPortal.Target}` on behalf of {sender}");
+            Log.Info($"Setting portal tag `{updatedPortal.Name}`, network `{updatedPortal.NetworkOwnerPlayerId}` (`{updatedPortal.NetworkOwnerDisplayName}`), target `{updatedPortal.Target}` on behalf of {sender}");
             ZdoTools.UpdateFromKnownPortal(state: updatedPortal);
 
             SendToClient.SyncPortal(updatedPortal);
@@ -104,6 +161,32 @@
             Log.Debug($"{sender} wants to receive the config");
             var pkg = XPortalConfig.Instance.PackLocalConfig();
             SendToClient.Config(sender, pkg);
+        }
+
+        /// <summary>
+        /// Client asks whether this connection is a server admin for portal network UI.
+        /// </summary>
+        internal static void RPC_RequestAdminSync(long sender, ZPackage _)
+        {
+            if (!Environment.IsServer)
+            {
+                return;
+            }
+
+            bool isAdmin = false;
+            var peer = ZNet.instance.GetPeer(sender);
+            if (peer != null)
+            {
+                isAdmin = ZNet.instance.IsAdmin(peer.m_socket.GetHostName());
+            }
+            else if (ZNet.instance.IsServer() && sender == ZNet.GetUID())
+            {
+                isAdmin = ZNet.instance.LocalPlayerIsAdminOrHost();
+            }
+
+            var outPkg = new ZPackage();
+            outPkg.Write(isAdmin);
+            ZRoutedRpc.instance.InvokeRoutedRPC(sender, RPCManager.RPC_ADMINSYNC, outPkg);
         }
     }
 }

--- a/XPortal/RPC/ServerEvents.cs
+++ b/XPortal/RPC/ServerEvents.cs
@@ -126,7 +126,8 @@ namespace XPortal.RPC.Server
                 var targetZdo = ZDOMan.instance.GetZDO(destForValidation.Id);
                 var destPieceCreator = targetZdo != null ? targetZdo.GetLong(ZDOVars.s_creator) : 0L;
                 var mayTargetPrivatePortal = NetPeerUtility.IsPeerPrivilegedForPortalNetwork(sender)
-                    || (destPieceCreator != 0L && destPieceCreator == requesterPlayerId);
+                    || (destPieceCreator != 0L && destPieceCreator == requesterPlayerId)
+                    || (destForValidation.NetworkOwnerPlayerId != 0L && destForValidation.NetworkOwnerPlayerId == requesterPlayerId);
                 if (!mayTargetPrivatePortal)
                 {
                     portal.Target = existing != null ? existing.Target : ZDOID.None;

--- a/XPortal/RPC/ServerEvents.cs
+++ b/XPortal/RPC/ServerEvents.cs
@@ -45,6 +45,7 @@ namespace XPortal.RPC.Server
             var pieceCreator = portalZdo.GetLong(ZDOVars.s_creator);
             var requesterIsCreator = requesterPlayerId != 0L && requesterPlayerId == pieceCreator;
             var requesterMayChangeNetwork = requesterIsCreator || NetPeerUtility.IsPeerPrivilegedForPortalNetwork(sender);
+            var requesterMayEditPrivatePortal = requesterIsCreator || NetPeerUtility.IsPeerPrivilegedForPortalNetwork(sender);
 
             KnownPortalsManager.Instance.TryGetValue(portal.Id, out var existing);
 
@@ -88,9 +89,53 @@ namespace XPortal.RPC.Server
                 }
             }
 
+            if (existing != null && existing.IsPrivate && !requesterMayEditPrivatePortal)
+            {
+                portal.Name = existing.Name;
+                portal.Target = existing.Target;
+                portal.IsPrivate = existing.IsPrivate;
+                portal.NetworkOwnerPlayerId = existing.NetworkOwnerPlayerId;
+                portal.NetworkOwnerDisplayName = existing.NetworkOwnerDisplayName ?? string.Empty;
+            }
+            else if (existing != null && !existing.IsPrivate && !requesterMayEditPrivatePortal)
+            {
+                portal.IsPrivate = false;
+                if (portal.HasTarget()
+                    && KnownPortalsManager.Instance.TryGetValue(portal.Target, out var blockedTarget)
+                    && blockedTarget.IsPrivate
+                    && blockedTarget.NetworkOwnerPlayerId == requesterPlayerId)
+                {
+                    portal.Target = existing.Target;
+                }
+            }
+
+            if (portal.IsPrivate)
+            {
+                if (pieceCreator == 0L)
+                {
+                    portal.IsPrivate = false;
+                }
+                else
+                {
+                    portal.NetworkOwnerPlayerId = pieceCreator;
+                }
+            }
+
+            if (portal.HasTarget() && KnownPortalsManager.Instance.TryGetValue(portal.Target, out var destForValidation) && destForValidation.IsPrivate)
+            {
+                var targetZdo = ZDOMan.instance.GetZDO(destForValidation.Id);
+                var destPieceCreator = targetZdo != null ? targetZdo.GetLong(ZDOVars.s_creator) : 0L;
+                var mayTargetPrivatePortal = NetPeerUtility.IsPeerPrivilegedForPortalNetwork(sender)
+                    || (destPieceCreator != 0L && destPieceCreator == requesterPlayerId);
+                if (!mayTargetPrivatePortal)
+                {
+                    portal.Target = existing != null ? existing.Target : ZDOID.None;
+                }
+            }
+
             var updatedPortal = KnownPortalsManager.Instance.AddOrUpdate(portal);
 
-            Log.Info($"Setting portal tag `{updatedPortal.Name}`, network `{updatedPortal.NetworkOwnerPlayerId}` (`{updatedPortal.NetworkOwnerDisplayName}`), target `{updatedPortal.Target}` on behalf of {sender}");
+            Log.Info($"Setting portal tag `{updatedPortal.Name}`, network `{updatedPortal.NetworkOwnerPlayerId}` (`{updatedPortal.NetworkOwnerDisplayName}`), private `{updatedPortal.IsPrivate}`, target `{updatedPortal.Target}` on behalf of {sender}");
             ZdoTools.UpdateFromKnownPortal(state: updatedPortal);
 
             SendToClient.SyncPortal(updatedPortal);

--- a/XPortal/RPC/ServerEvents.cs
+++ b/XPortal/RPC/ServerEvents.cs
@@ -1,7 +1,4 @@
-﻿using XPortal;
-using XPortal.RPC;
-
-namespace XPortal.RPC.Server
+﻿namespace XPortal.RPC.Server
 {
     internal static class ServerEvents
     {
@@ -64,6 +61,19 @@ namespace XPortal.RPC.Server
                 if (portal.NetworkOwnerPlayerId == 0L)
                 {
                     portal.NetworkOwnerDisplayName = string.Empty;
+                }
+                else if (CustomNetworks.IsReservedIdRange(portal.NetworkOwnerPlayerId))
+                {
+                    if (CustomNetworks.IsActiveId(portal.NetworkOwnerPlayerId)
+                        && CustomNetworks.TryGetDisplayName(portal.NetworkOwnerPlayerId, out var customName))
+                    {
+                        portal.NetworkOwnerDisplayName = customName;
+                    }
+                    else
+                    {
+                        portal.NetworkOwnerPlayerId = 0L;
+                        portal.NetworkOwnerDisplayName = string.Empty;
+                    }
                 }
                 else
                 {
@@ -207,6 +217,19 @@ namespace XPortal.RPC.Server
             Log.Debug($"{sender} wants to receive the config");
             var pkg = XPortalConfig.Instance.PackLocalConfig();
             SendToClient.Config(sender, pkg);
+        }
+
+        /// <summary>Client asks for the custom network list.</summary>
+        internal static void RPC_RequestCustomNetworks(long sender)
+        {
+            if (!Environment.IsServer)
+            {
+                Log.Error($"{sender} wants custom networks, but I am not the server!");
+                return;
+            }
+
+            Log.Debug($"{sender} wants custom networks");
+            SendToClient.CustomNetworks(sender, CustomNetworks.PackForServer());
         }
 
         /// <summary>

--- a/XPortal/RPC/XPortalAdminSync.cs
+++ b/XPortal/RPC/XPortalAdminSync.cs
@@ -1,5 +1,3 @@
-using XPortal;
-
 namespace XPortal.RPC
 {
     /// <summary>

--- a/XPortal/RPC/XPortalAdminSync.cs
+++ b/XPortal/RPC/XPortalAdminSync.cs
@@ -1,0 +1,66 @@
+using XPortal;
+
+namespace XPortal.RPC
+{
+    /// <summary>
+    /// Server-confirmed admin access for portal network UI. Hosts do not use the RPC.
+    /// </summary>
+    internal static class XPortalAdminSync
+    {
+        private static bool _requestedThisSession;
+        private static bool _serverReplyReceived;
+        private static bool _serverSaysAdmin;
+
+        internal static void ResetForNewSession()
+        {
+            _requestedThisSession = false;
+            _serverReplyReceived = false;
+            _serverSaysAdmin = false;
+        }
+
+        internal static bool IsLocalPortalNetworkAdmin()
+        {
+            if (ZNet.instance == null)
+            {
+                return false;
+            }
+
+            if (ZNet.instance.IsServer())
+            {
+                return true;
+            }
+
+            if (_serverReplyReceived)
+            {
+                return _serverSaysAdmin;
+            }
+
+            var userId = UserInfo.GetLocalUser().UserId;
+            return userId.IsValid && ZNet.instance.PlayerIsAdmin(userId);
+        }
+
+        internal static void ApplyServerReply(bool isAdmin)
+        {
+            _serverSaysAdmin = isAdmin;
+            _serverReplyReceived = true;
+        }
+
+        internal static void RequestFromServerIfNeeded()
+        {
+            if (ZNet.instance == null || ZNet.instance.IsServer())
+            {
+                return;
+            }
+
+            if (_requestedThisSession)
+            {
+                return;
+            }
+
+            _requestedThisSession = true;
+            var pkg = new ZPackage();
+            ZRoutedRpc.instance.InvokeRoutedRPC(Environment.ServerPeerId, RPCManager.RPC_REQUESTADMINSYNC, pkg);
+            Log.Debug("Requested portal network admin status from server");
+        }
+    }
+}

--- a/XPortal/Translations/Chinese/xportal-translation-chinese.json
+++ b/XPortal/Translations/Chinese/xportal-translation-chinese.json
@@ -12,5 +12,7 @@
   "hud_xportal_destination_portal": "传送门",
   "hud_xportal_network_global": "全局传送门",
   "hud_xportal_network_suffix": "传送门",
-  "hud_xportal_no_destinations": "没有其他传送门"
+  "hud_xportal_no_destinations": "没有其他传送门",
+  "piece_portal_private": "私人传送门",
+  "hud_xportal_network_my_private": "我的私人传送门"
 }

--- a/XPortal/Translations/Chinese/xportal-translation-chinese.json
+++ b/XPortal/Translations/Chinese/xportal-translation-chinese.json
@@ -6,5 +6,11 @@
   "piece_portal_target_none": "(无)",
   "piece_portal_tag_none": "(无名称)",
   "piece_portal_defaultportal": "Default portal",
-  "hud_xportal_title": "道路千万条，安全第一条！"
+  "hud_xportal_title": "道路千万条，安全第一条！",
+  "hud_xportal_portal_network": "传送门网络",
+  "hud_xportal_destination_network": "目标网络",
+  "hud_xportal_destination_portal": "传送门",
+  "hud_xportal_network_global": "全局传送门",
+  "hud_xportal_network_suffix": "传送门",
+  "hud_xportal_no_destinations": "没有其他传送门"
 }

--- a/XPortal/Translations/Chinese/xportal-translation-chinese.json
+++ b/XPortal/Translations/Chinese/xportal-translation-chinese.json
@@ -14,5 +14,7 @@
   "hud_xportal_network_suffix": "传送门",
   "hud_xportal_no_destinations": "没有其他传送门",
   "piece_portal_private": "私人传送门",
-  "hud_xportal_network_my_private": "我的私人传送门"
+  "hud_xportal_network_my_private": "我的私人传送门",
+  "settings_dropdown_scrollup": "下拉列表向上滚动",
+  "settings_dropdown_scrolldown": "下拉列表向下滚动"
 }

--- a/XPortal/Translations/Dutch/xportal-translations-dutch.json
+++ b/XPortal/Translations/Dutch/xportal-translations-dutch.json
@@ -12,5 +12,7 @@
   "hud_xportal_destination_portal": "Portaal",
   "hud_xportal_network_global": "Globale portalen",
   "hud_xportal_network_suffix": "Portalen",
-  "hud_xportal_no_destinations": "Geen andere portalen"
+  "hud_xportal_no_destinations": "Geen andere portalen",
+  "piece_portal_private": "Privéportaal",
+  "hud_xportal_network_my_private": "Mijn privéportalen"
 }

--- a/XPortal/Translations/Dutch/xportal-translations-dutch.json
+++ b/XPortal/Translations/Dutch/xportal-translations-dutch.json
@@ -6,5 +6,11 @@
   "piece_portal_target_none": "(Geen)",
   "piece_portal_tag_none": "(Geen naam)",
   "piece_portal_defaultportal": "Standaardportaal",
-  "hud_xportal_title": "Gegroet, reiziger!"
+  "hud_xportal_title": "Gegroet, reiziger!",
+  "hud_xportal_portal_network": "Portaalnetwerk",
+  "hud_xportal_destination_network": "Bestemmingsnetwerk",
+  "hud_xportal_destination_portal": "Portaal",
+  "hud_xportal_network_global": "Globale portalen",
+  "hud_xportal_network_suffix": "Portalen",
+  "hud_xportal_no_destinations": "Geen andere portalen"
 }

--- a/XPortal/Translations/Dutch/xportal-translations-dutch.json
+++ b/XPortal/Translations/Dutch/xportal-translations-dutch.json
@@ -14,5 +14,7 @@
   "hud_xportal_network_suffix": "Portalen",
   "hud_xportal_no_destinations": "Geen andere portalen",
   "piece_portal_private": "Privéportaal",
-  "hud_xportal_network_my_private": "Mijn privéportalen"
+  "hud_xportal_network_my_private": "Mijn privéportalen",
+  "settings_dropdown_scrollup": "Dropdown omhoog scrollen",
+  "settings_dropdown_scrolldown": "Dropdown omlaag scrollen"
 }

--- a/XPortal/Translations/English/xportal-translations-english.json
+++ b/XPortal/Translations/English/xportal-translations-english.json
@@ -5,6 +5,12 @@
   "piece_portal_target": "Destination",
   "piece_portal_target_none": "(None)",
   "piece_portal_tag_none": "(No Name)",
-  "piece_portal_defaultportal":  "Default portal",
-  "hud_xportal_title": "Hail, traveller!"
+  "piece_portal_defaultportal": "Default portal",
+  "hud_xportal_title": "Hail, traveller!",
+  "hud_xportal_portal_network": "Portal network",
+  "hud_xportal_destination_network": "Destination network",
+  "hud_xportal_destination_portal": "Portal",
+  "hud_xportal_network_global": "Global Portals",
+  "hud_xportal_network_suffix": "Portals",
+  "hud_xportal_no_destinations": "No other portals"
 }

--- a/XPortal/Translations/English/xportal-translations-english.json
+++ b/XPortal/Translations/English/xportal-translations-english.json
@@ -14,5 +14,7 @@
   "hud_xportal_network_suffix": "Portals",
   "hud_xportal_no_destinations": "No other portals",
   "piece_portal_private": "Private portal",
-  "hud_xportal_network_my_private": "My Private Portals"
+  "hud_xportal_network_my_private": "My Private Portals",
+  "settings_dropdown_scrollup": "Dropdown scroll up",
+  "settings_dropdown_scrolldown": "Dropdown scroll down"
 }

--- a/XPortal/Translations/English/xportal-translations-english.json
+++ b/XPortal/Translations/English/xportal-translations-english.json
@@ -12,5 +12,7 @@
   "hud_xportal_destination_portal": "Portal",
   "hud_xportal_network_global": "Global Portals",
   "hud_xportal_network_suffix": "Portals",
-  "hud_xportal_no_destinations": "No other portals"
+  "hud_xportal_no_destinations": "No other portals",
+  "piece_portal_private": "Private portal",
+  "hud_xportal_network_my_private": "My Private Portals"
 }

--- a/XPortal/Translations/French/xportal-translations-french.json
+++ b/XPortal/Translations/French/xportal-translations-french.json
@@ -14,5 +14,7 @@
   "hud_xportal_network_suffix": "Portails",
   "hud_xportal_no_destinations": "Aucun autre portail",
   "piece_portal_private": "Portail privé",
-  "hud_xportal_network_my_private": "Mes portails privés"
+  "hud_xportal_network_my_private": "Mes portails privés",
+  "settings_dropdown_scrollup": "Défilement du menu déroulant (haut)",
+  "settings_dropdown_scrolldown": "Défilement du menu déroulant (bas)"
 }

--- a/XPortal/Translations/French/xportal-translations-french.json
+++ b/XPortal/Translations/French/xportal-translations-french.json
@@ -12,5 +12,7 @@
   "hud_xportal_destination_portal": "Portail",
   "hud_xportal_network_global": "Portails globaux",
   "hud_xportal_network_suffix": "Portails",
-  "hud_xportal_no_destinations": "Aucun autre portail"
+  "hud_xportal_no_destinations": "Aucun autre portail",
+  "piece_portal_private": "Portail privé",
+  "hud_xportal_network_my_private": "Mes portails privés"
 }

--- a/XPortal/Translations/French/xportal-translations-french.json
+++ b/XPortal/Translations/French/xportal-translations-french.json
@@ -6,5 +6,11 @@
   "piece_portal_target_none": "(Aucun)",
   "piece_portal_tag_none": "(Sans nom)",
   "piece_portal_defaultportal": "Default portal",
-  "hud_xportal_title": "Salutations, voyageur !"
+  "hud_xportal_title": "Salutations, voyageur !",
+  "hud_xportal_portal_network": "Réseau du portail",
+  "hud_xportal_destination_network": "Réseau de destination",
+  "hud_xportal_destination_portal": "Portail",
+  "hud_xportal_network_global": "Portails globaux",
+  "hud_xportal_network_suffix": "Portails",
+  "hud_xportal_no_destinations": "Aucun autre portail"
 }

--- a/XPortal/Translations/German/xportal-translations-german.json
+++ b/XPortal/Translations/German/xportal-translations-german.json
@@ -6,5 +6,11 @@
   "piece_portal_target_none": "(Keins)",
   "piece_portal_tag_none": "(Kein Name)",
   "piece_portal_defaultportal": "Default portal",
-  "hud_xportal_title": "Sei gegrüßt, Reisender!"
+  "hud_xportal_title": "Sei gegrüßt, Reisender!",
+  "hud_xportal_portal_network": "Portal-Netzwerk",
+  "hud_xportal_destination_network": "Ziel-Netzwerk",
+  "hud_xportal_destination_portal": "Portal",
+  "hud_xportal_network_global": "Globale Portale",
+  "hud_xportal_network_suffix": "Portale",
+  "hud_xportal_no_destinations": "Keine anderen Portale"
 }

--- a/XPortal/Translations/German/xportal-translations-german.json
+++ b/XPortal/Translations/German/xportal-translations-german.json
@@ -12,5 +12,7 @@
   "hud_xportal_destination_portal": "Portal",
   "hud_xportal_network_global": "Globale Portale",
   "hud_xportal_network_suffix": "Portale",
-  "hud_xportal_no_destinations": "Keine anderen Portale"
+  "hud_xportal_no_destinations": "Keine anderen Portale",
+  "piece_portal_private": "Privates Portal",
+  "hud_xportal_network_my_private": "Meine privaten Portale"
 }

--- a/XPortal/Translations/German/xportal-translations-german.json
+++ b/XPortal/Translations/German/xportal-translations-german.json
@@ -14,5 +14,7 @@
   "hud_xportal_network_suffix": "Portale",
   "hud_xportal_no_destinations": "Keine anderen Portale",
   "piece_portal_private": "Privates Portal",
-  "hud_xportal_network_my_private": "Meine privaten Portale"
+  "hud_xportal_network_my_private": "Meine privaten Portale",
+  "settings_dropdown_scrollup": "Dropdown nach oben scrollen",
+  "settings_dropdown_scrolldown": "Dropdown nach unten scrollen"
 }

--- a/XPortal/Translations/Italian/xportal-translations-italian.json
+++ b/XPortal/Translations/Italian/xportal-translations-italian.json
@@ -14,5 +14,7 @@
   "hud_xportal_network_suffix": "Portali",
   "hud_xportal_no_destinations": "Nessun altro portale",
   "piece_portal_private": "Portale privato",
-  "hud_xportal_network_my_private": "I miei portali privati"
+  "hud_xportal_network_my_private": "I miei portali privati",
+  "settings_dropdown_scrollup": "Scorri menu a tendina su",
+  "settings_dropdown_scrolldown": "Scorri menu a tendina giù"
 }

--- a/XPortal/Translations/Italian/xportal-translations-italian.json
+++ b/XPortal/Translations/Italian/xportal-translations-italian.json
@@ -12,5 +12,7 @@
   "hud_xportal_destination_portal": "Portale",
   "hud_xportal_network_global": "Portali globali",
   "hud_xportal_network_suffix": "Portali",
-  "hud_xportal_no_destinations": "Nessun altro portale"
+  "hud_xportal_no_destinations": "Nessun altro portale",
+  "piece_portal_private": "Portale privato",
+  "hud_xportal_network_my_private": "I miei portali privati"
 }

--- a/XPortal/Translations/Italian/xportal-translations-italian.json
+++ b/XPortal/Translations/Italian/xportal-translations-italian.json
@@ -6,5 +6,11 @@
   "piece_portal_target_none": "(Nessuno)",
   "piece_portal_tag_none": "(Senza nome)",
   "piece_portal_defaultportal": "Default portal",
-  "hud_xportal_title": "Salute, viaggiatore!"
+  "hud_xportal_title": "Salute, viaggiatore!",
+  "hud_xportal_portal_network": "Rete del portale",
+  "hud_xportal_destination_network": "Rete di destinazione",
+  "hud_xportal_destination_portal": "Portale",
+  "hud_xportal_network_global": "Portali globali",
+  "hud_xportal_network_suffix": "Portali",
+  "hud_xportal_no_destinations": "Nessun altro portale"
 }

--- a/XPortal/Translations/Japanese/xportal-translations-japanese.json
+++ b/XPortal/Translations/Japanese/xportal-translations-japanese.json
@@ -6,5 +6,11 @@
   "piece_portal_target_none": "(無指定)",
   "piece_portal_tag_none": "(無名)",
   "piece_portal_defaultportal": "既定ポータル",
-  "hud_xportal_title": "やあ、トラベラー!"
+  "hud_xportal_title": "やあ、トラベラー!",
+  "hud_xportal_portal_network": "ポータルネットワーク",
+  "hud_xportal_destination_network": "接続先ネットワーク",
+  "hud_xportal_destination_portal": "ポータル",
+  "hud_xportal_network_global": "グローバルポータル",
+  "hud_xportal_network_suffix": "ポータル",
+  "hud_xportal_no_destinations": "他にポータルがありません"
 }

--- a/XPortal/Translations/Japanese/xportal-translations-japanese.json
+++ b/XPortal/Translations/Japanese/xportal-translations-japanese.json
@@ -12,5 +12,7 @@
   "hud_xportal_destination_portal": "ポータル",
   "hud_xportal_network_global": "グローバルポータル",
   "hud_xportal_network_suffix": "ポータル",
-  "hud_xportal_no_destinations": "他にポータルがありません"
+  "hud_xportal_no_destinations": "他にポータルがありません",
+  "piece_portal_private": "プライベートポータル",
+  "hud_xportal_network_my_private": "自分のプライベートポータル"
 }

--- a/XPortal/Translations/Japanese/xportal-translations-japanese.json
+++ b/XPortal/Translations/Japanese/xportal-translations-japanese.json
@@ -14,5 +14,7 @@
   "hud_xportal_network_suffix": "ポータル",
   "hud_xportal_no_destinations": "他にポータルがありません",
   "piece_portal_private": "プライベートポータル",
-  "hud_xportal_network_my_private": "自分のプライベートポータル"
+  "hud_xportal_network_my_private": "自分のプライベートポータル",
+  "settings_dropdown_scrollup": "ドロップダウンを上にスクロール",
+  "settings_dropdown_scrolldown": "ドロップダウンを下にスクロール"
 }

--- a/XPortal/Translations/Korean/xportal-translations-korean.json
+++ b/XPortal/Translations/Korean/xportal-translations-korean.json
@@ -14,5 +14,7 @@
   "hud_xportal_network_suffix": "포털",
   "hud_xportal_no_destinations": "다른 포털 없음",
   "piece_portal_private": "비공개 포털",
-  "hud_xportal_network_my_private": "내 비공개 포털"
+  "hud_xportal_network_my_private": "내 비공개 포털",
+  "settings_dropdown_scrollup": "드롭다운 위로 스크롤",
+  "settings_dropdown_scrolldown": "드롭다운 아래로 스크롤"
 }

--- a/XPortal/Translations/Korean/xportal-translations-korean.json
+++ b/XPortal/Translations/Korean/xportal-translations-korean.json
@@ -6,5 +6,11 @@
   "piece_portal_target_none": "(없음)",
   "piece_portal_tag_none": "(이름 없음)",
   "piece_portal_defaultportal": "Default portal",
-  "hud_xportal_title": "여행자여, 만세!"
+  "hud_xportal_title": "여행자여, 만세!",
+  "hud_xportal_portal_network": "포털 네트워크",
+  "hud_xportal_destination_network": "목적지 네트워크",
+  "hud_xportal_destination_portal": "포털",
+  "hud_xportal_network_global": "전역 포털",
+  "hud_xportal_network_suffix": "포털",
+  "hud_xportal_no_destinations": "다른 포털 없음"
 }

--- a/XPortal/Translations/Korean/xportal-translations-korean.json
+++ b/XPortal/Translations/Korean/xportal-translations-korean.json
@@ -12,5 +12,7 @@
   "hud_xportal_destination_portal": "포털",
   "hud_xportal_network_global": "전역 포털",
   "hud_xportal_network_suffix": "포털",
-  "hud_xportal_no_destinations": "다른 포털 없음"
+  "hud_xportal_no_destinations": "다른 포털 없음",
+  "piece_portal_private": "비공개 포털",
+  "hud_xportal_network_my_private": "내 비공개 포털"
 }

--- a/XPortal/Translations/Polish/xportal-translations-polish.json
+++ b/XPortal/Translations/Polish/xportal-translations-polish.json
@@ -14,5 +14,7 @@
   "hud_xportal_network_suffix": "Portale",
   "hud_xportal_no_destinations": "Brak innych portali",
   "piece_portal_private": "Portal prywatny",
-  "hud_xportal_network_my_private": "Moje prywatne portale"
+  "hud_xportal_network_my_private": "Moje prywatne portale",
+  "settings_dropdown_scrollup": "Przewijanie listy rozwijanej w górę",
+  "settings_dropdown_scrolldown": "Przewijanie listy rozwijanej w dół"
 }

--- a/XPortal/Translations/Polish/xportal-translations-polish.json
+++ b/XPortal/Translations/Polish/xportal-translations-polish.json
@@ -6,5 +6,11 @@
   "piece_portal_target_none": "(Brak Celu)",
   "piece_portal_tag_none": "(Bez Nazwy)",
   "piece_portal_defaultportal": "Default portal",
-  "hud_xportal_title": "Witaj, Podróżniku!"
+  "hud_xportal_title": "Witaj, Podróżniku!",
+  "hud_xportal_portal_network": "Sieć portalu",
+  "hud_xportal_destination_network": "Sieć docelowa",
+  "hud_xportal_destination_portal": "Portal",
+  "hud_xportal_network_global": "Globalne portale",
+  "hud_xportal_network_suffix": "Portale",
+  "hud_xportal_no_destinations": "Brak innych portali"
 }

--- a/XPortal/Translations/Polish/xportal-translations-polish.json
+++ b/XPortal/Translations/Polish/xportal-translations-polish.json
@@ -12,5 +12,7 @@
   "hud_xportal_destination_portal": "Portal",
   "hud_xportal_network_global": "Globalne portale",
   "hud_xportal_network_suffix": "Portale",
-  "hud_xportal_no_destinations": "Brak innych portali"
+  "hud_xportal_no_destinations": "Brak innych portali",
+  "piece_portal_private": "Portal prywatny",
+  "hud_xportal_network_my_private": "Moje prywatne portale"
 }

--- a/XPortal/Translations/Portuguese_Brazilian/xportal-translations-portuguese_brazillian.json
+++ b/XPortal/Translations/Portuguese_Brazilian/xportal-translations-portuguese_brazillian.json
@@ -6,5 +6,11 @@
   "piece_portal_target_none": "(Nenhum)",
   "piece_portal_tag_none": "(Sem nome)",
   "piece_portal_defaultportal": "Default portal",
-  "hud_xportal_title": "Salve, viajante!"
+  "hud_xportal_title": "Salve, viajante!",
+  "hud_xportal_portal_network": "Rede do portal",
+  "hud_xportal_destination_network": "Rede de destino",
+  "hud_xportal_destination_portal": "Portal",
+  "hud_xportal_network_global": "Portais globais",
+  "hud_xportal_network_suffix": "Portais",
+  "hud_xportal_no_destinations": "Nenhum outro portal"
 }

--- a/XPortal/Translations/Portuguese_Brazilian/xportal-translations-portuguese_brazillian.json
+++ b/XPortal/Translations/Portuguese_Brazilian/xportal-translations-portuguese_brazillian.json
@@ -12,5 +12,7 @@
   "hud_xportal_destination_portal": "Portal",
   "hud_xportal_network_global": "Portais globais",
   "hud_xportal_network_suffix": "Portais",
-  "hud_xportal_no_destinations": "Nenhum outro portal"
+  "hud_xportal_no_destinations": "Nenhum outro portal",
+  "piece_portal_private": "Portal privado",
+  "hud_xportal_network_my_private": "Meus portais privados"
 }

--- a/XPortal/Translations/Portuguese_Brazilian/xportal-translations-portuguese_brazillian.json
+++ b/XPortal/Translations/Portuguese_Brazilian/xportal-translations-portuguese_brazillian.json
@@ -14,5 +14,7 @@
   "hud_xportal_network_suffix": "Portais",
   "hud_xportal_no_destinations": "Nenhum outro portal",
   "piece_portal_private": "Portal privado",
-  "hud_xportal_network_my_private": "Meus portais privados"
+  "hud_xportal_network_my_private": "Meus portais privados",
+  "settings_dropdown_scrollup": "Rolar lista suspensa para cima",
+  "settings_dropdown_scrolldown": "Rolar lista suspensa para baixo"
 }

--- a/XPortal/Translations/Russian/xportal-translations-russian.json
+++ b/XPortal/Translations/Russian/xportal-translations-russian.json
@@ -6,5 +6,11 @@
   "piece_portal_target_none": "(Нет Цели)",
   "piece_portal_tag_none": "(Без Имени)",
   "piece_portal_defaultportal": "Default portal",
-  "hud_xportal_title": "Привет, путник!"
+  "hud_xportal_title": "Привет, путник!",
+  "hud_xportal_portal_network": "Сеть портала",
+  "hud_xportal_destination_network": "Сеть назначения",
+  "hud_xportal_destination_portal": "Портал",
+  "hud_xportal_network_global": "Глобальные порталы",
+  "hud_xportal_network_suffix": "Порталы",
+  "hud_xportal_no_destinations": "Нет других порталов"
 }

--- a/XPortal/Translations/Russian/xportal-translations-russian.json
+++ b/XPortal/Translations/Russian/xportal-translations-russian.json
@@ -12,5 +12,7 @@
   "hud_xportal_destination_portal": "Портал",
   "hud_xportal_network_global": "Глобальные порталы",
   "hud_xportal_network_suffix": "Порталы",
-  "hud_xportal_no_destinations": "Нет других порталов"
+  "hud_xportal_no_destinations": "Нет других порталов",
+  "piece_portal_private": "Частный портал",
+  "hud_xportal_network_my_private": "Мои частные порталы"
 }

--- a/XPortal/Translations/Russian/xportal-translations-russian.json
+++ b/XPortal/Translations/Russian/xportal-translations-russian.json
@@ -14,5 +14,7 @@
   "hud_xportal_network_suffix": "Порталы",
   "hud_xportal_no_destinations": "Нет других порталов",
   "piece_portal_private": "Частный портал",
-  "hud_xportal_network_my_private": "Мои частные порталы"
+  "hud_xportal_network_my_private": "Мои частные порталы",
+  "settings_dropdown_scrollup": "Прокрутка выпадающего списка вверх",
+  "settings_dropdown_scrolldown": "Прокрутка выпадающего списка вниз"
 }

--- a/XPortal/Translations/Spanish/xportal-translations-spanish.json
+++ b/XPortal/Translations/Spanish/xportal-translations-spanish.json
@@ -14,5 +14,7 @@
   "hud_xportal_network_suffix": "Portales",
   "hud_xportal_no_destinations": "No hay otros portales",
   "piece_portal_private": "Portal privado",
-  "hud_xportal_network_my_private": "Mis portales privados"
+  "hud_xportal_network_my_private": "Mis portales privados",
+  "settings_dropdown_scrollup": "Desplazar menú desplegable arriba",
+  "settings_dropdown_scrolldown": "Desplazar menú desplegable abajo"
 }

--- a/XPortal/Translations/Spanish/xportal-translations-spanish.json
+++ b/XPortal/Translations/Spanish/xportal-translations-spanish.json
@@ -12,5 +12,7 @@
   "hud_xportal_destination_portal": "Portal",
   "hud_xportal_network_global": "Portales globales",
   "hud_xportal_network_suffix": "Portales",
-  "hud_xportal_no_destinations": "No hay otros portales"
+  "hud_xportal_no_destinations": "No hay otros portales",
+  "piece_portal_private": "Portal privado",
+  "hud_xportal_network_my_private": "Mis portales privados"
 }

--- a/XPortal/Translations/Spanish/xportal-translations-spanish.json
+++ b/XPortal/Translations/Spanish/xportal-translations-spanish.json
@@ -6,5 +6,11 @@
   "piece_portal_target_none": "(Ninguno)",
   "piece_portal_tag_none": "(Sin nombre)",
   "piece_portal_defaultportal": "Default portal",
-  "hud_xportal_title": "¡ Saludos, viajero !"
+  "hud_xportal_title": "¡ Saludos, viajero !",
+  "hud_xportal_portal_network": "Red del portal",
+  "hud_xportal_destination_network": "Red de destino",
+  "hud_xportal_destination_portal": "Portal",
+  "hud_xportal_network_global": "Portales globales",
+  "hud_xportal_network_suffix": "Portales",
+  "hud_xportal_no_destinations": "No hay otros portales"
 }

--- a/XPortal/Translations/Ukrainian/xportal-translations-ukrainian.json
+++ b/XPortal/Translations/Ukrainian/xportal-translations-ukrainian.json
@@ -12,5 +12,7 @@
   "hud_xportal_destination_portal": "Портал",
   "hud_xportal_network_global": "Глобальні портали",
   "hud_xportal_network_suffix": "Портали",
-  "hud_xportal_no_destinations": "Інших порталів немає"
+  "hud_xportal_no_destinations": "Інших порталів немає",
+  "piece_portal_private": "Приватний портал",
+  "hud_xportal_network_my_private": "Мої приватні портали"
 }

--- a/XPortal/Translations/Ukrainian/xportal-translations-ukrainian.json
+++ b/XPortal/Translations/Ukrainian/xportal-translations-ukrainian.json
@@ -6,5 +6,11 @@
   "piece_portal_target_none": "(Немає)",
   "piece_portal_tag_none": "(Без назви)",
   "piece_portal_defaultportal":  "Портал за-замовчуванням",
-  "hud_xportal_title": "Привіт, мандрівнику!"
+  "hud_xportal_title": "Привіт, мандрівнику!",
+  "hud_xportal_portal_network": "Мережа порталу",
+  "hud_xportal_destination_network": "Мережа призначення",
+  "hud_xportal_destination_portal": "Портал",
+  "hud_xportal_network_global": "Глобальні портали",
+  "hud_xportal_network_suffix": "Портали",
+  "hud_xportal_no_destinations": "Інших порталів немає"
 }

--- a/XPortal/Translations/Ukrainian/xportal-translations-ukrainian.json
+++ b/XPortal/Translations/Ukrainian/xportal-translations-ukrainian.json
@@ -14,5 +14,7 @@
   "hud_xportal_network_suffix": "Портали",
   "hud_xportal_no_destinations": "Інших порталів немає",
   "piece_portal_private": "Приватний портал",
-  "hud_xportal_network_my_private": "Мої приватні портали"
+  "hud_xportal_network_my_private": "Мої приватні портали",
+  "settings_dropdown_scrollup": "Прокрутка списку вгору",
+  "settings_dropdown_scrolldown": "Прокрутка списку вниз"
 }

--- a/XPortal/UI/PortalConfigurationPanel.cs
+++ b/XPortal/UI/PortalConfigurationPanel.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
-using XPortal;
 
 namespace XPortal.UI
 {
@@ -90,6 +89,8 @@ namespace XPortal.UI
         // A look-up list to find the portal ZDOID by dropdown list index
         private readonly Dictionary<int, ZDOID> dropdownIndexToZDOIDMapping;
         private readonly Dictionary<int, long> destinationNetworkIndexToOwnerId = new Dictionary<int, long>();
+        private readonly Dictionary<int, long> networkAssignmentIndexToOwnerId = new Dictionary<int, long>();
+        private int personalNetworkAssignmentIndex;
 
         // The KnownPortal being configured
         private KnownPortal thisPortal;
@@ -103,7 +104,7 @@ namespace XPortal.UI
         private long personalNetworkOwnerId;
         private bool readOnlyPrivatePortal;
 
-        /// <summary>Piece <see cref="ZDOVars.s_creator"/>; personal network option uses this owner id (admin editing someone else's portal).</summary>
+        /// <summary>Piece creator id; personal network row uses this owner (e.g. admin editing another player's portal).</summary>
         private long pieceCreatorPlayerId;
 
         #region Input Button Configs
@@ -342,14 +343,47 @@ namespace XPortal.UI
 
             if (isOn)
             {
-                networkAssignmentDropdown.SetValueWithoutNotify(1);
+                networkAssignmentDropdown.SetValueWithoutNotify(personalNetworkAssignmentIndex);
             }
+        }
+
+        internal void OnNetworksListChanged()
+        {
+            if (!IsActive() || thisPortal == null)
+            {
+                return;
+            }
+
+            if (!KnownPortalsManager.Instance.TryGetValue(thisPortal.Id, out var fresh))
+            {
+                return;
+            }
+
+            thisPortal = fresh;
+            PopulateNetworkAssignmentDropdown();
+            PopulateDestinationNetworkDropdown();
+            PopulateDestinationPortalDropdown();
+            ApplyReadOnlyState();
+        }
+
+        private int FindNetworkAssignmentDropdownIndex(long networkOwnerPlayerId)
+        {
+            foreach (var kvp in networkAssignmentIndexToOwnerId)
+            {
+                if (kvp.Value == networkOwnerPlayerId)
+                {
+                    return kvp.Key;
+                }
+            }
+
+            return -1;
         }
 
         private void PopulateNetworkAssignmentDropdown()
         {
             networkAssignmentDropdown.onValueChanged.RemoveAllListeners();
             networkAssignmentDropdown.ClearOptions();
+            networkAssignmentIndexToOwnerId.Clear();
 
             if (!canEditNetworkAssignment)
             {
@@ -362,24 +396,35 @@ namespace XPortal.UI
             }
 
             networkAssignmentDropdown.interactable = true;
-            networkAssignmentDropdown.options.Add(new Dropdown.OptionData(PortalNetwork.FormatNetworkLabel(0L)));
+
             var localPlayerId = Player.m_localPlayer != null
                 ? Player.m_localPlayer.GetPlayerID()
                 : Game.instance.GetPlayerProfile().GetPlayerID();
-            long personalNetworkOwnerId = pieceCreatorPlayerId != 0L ? pieceCreatorPlayerId : localPlayerId;
+            var personalNetworkOwnerId = pieceCreatorPlayerId != 0L ? pieceCreatorPlayerId : localPlayerId;
+
+            var index = -1;
+
+            networkAssignmentDropdown.options.Add(new Dropdown.OptionData(PortalNetwork.FormatNetworkLabel(0L)));
+            networkAssignmentIndexToOwnerId.Add(++index, 0L);
+
+            foreach (var customId in CustomNetworks.GetSortedActiveIds())
+            {
+                networkAssignmentDropdown.options.Add(new Dropdown.OptionData(PortalNetwork.FormatNetworkLabel(customId)));
+                networkAssignmentIndexToOwnerId.Add(++index, customId);
+            }
+
             networkAssignmentDropdown.options.Add(new Dropdown.OptionData(PortalNetwork.FormatNetworkLabel(personalNetworkOwnerId)));
+            networkAssignmentIndexToOwnerId.Add(++index, personalNetworkOwnerId);
+            personalNetworkAssignmentIndex = index;
 
             if (thisPortal.IsPrivate)
             {
-                networkAssignmentDropdown.value = 1;
-            }
-            else if (thisPortal.NetworkOwnerPlayerId == 0L)
-            {
-                networkAssignmentDropdown.value = 0;
+                networkAssignmentDropdown.value = personalNetworkAssignmentIndex;
             }
             else
             {
-                networkAssignmentDropdown.value = 1;
+                var matchIdx = FindNetworkAssignmentDropdownIndex(thisPortal.NetworkOwnerPlayerId);
+                networkAssignmentDropdown.value = matchIdx >= 0 ? matchIdx : 0;
             }
 
             ApplyDropdownStyle(networkAssignmentDropdown);
@@ -389,7 +434,17 @@ namespace XPortal.UI
 
         private void OnNetworkAssignmentDropdownValueChanged(Dropdown change)
         {
-            if (change.value == 0 && privatePortalToggle.isOn)
+            if (!networkAssignmentIndexToOwnerId.TryGetValue(change.value, out var ownerId))
+            {
+                return;
+            }
+
+            var localPlayerId = Player.m_localPlayer != null
+                ? Player.m_localPlayer.GetPlayerID()
+                : Game.instance.GetPlayerProfile().GetPlayerID();
+            var personalId = pieceCreatorPlayerId != 0L ? pieceCreatorPlayerId : localPlayerId;
+
+            if (ownerId != personalId && privatePortalToggle.isOn)
             {
                 privatePortalToggle.SetIsOnWithoutNotify(false);
             }
@@ -412,12 +467,12 @@ namespace XPortal.UI
                 return personalId;
             }
 
-            if (networkAssignmentDropdown.value == 0)
+            if (!networkAssignmentIndexToOwnerId.TryGetValue(networkAssignmentDropdown.value, out var ownerId))
             {
-                return 0L;
+                return thisPortal.NetworkOwnerPlayerId;
             }
 
-            return personalId;
+            return ownerId;
         }
 
         private void PopulateDestinationNetworkDropdown()

--- a/XPortal/UI/PortalConfigurationPanel.cs
+++ b/XPortal/UI/PortalConfigurationPanel.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using XPortal;
 
 namespace XPortal.UI
 {
@@ -28,6 +29,8 @@ namespace XPortal.UI
         internal const string GO_PINGMAPBUTTON = Mod.Info.Name + "_PingMapButton";
         internal const string GO_DEFAULTPORTALLABEL = Mod.Info.Name + "_DefaultPortalHeader";
         internal const string GO_DEFAULTPORTALCHECKBOX = Mod.Info.Name + "_DefaultPortalCheckbox";
+        internal const string GO_PRIVATEPORTALLABEL = Mod.Info.Name + "_PrivatePortalHeader";
+        internal const string GO_PRIVATEPORTALCHECKBOX = Mod.Info.Name + "_PrivatePortalCheckbox";
         internal const string GO_OKAYBUTTON = Mod.Info.Name + "_OkayButton";
         internal const string GO_CANCELBUTTON = Mod.Info.Name + "_CancelButton";
         internal const string GO_NETWORKASSIGNLABEL = Mod.Info.Name + "_NetworkAssignHeader";
@@ -65,7 +68,8 @@ namespace XPortal.UI
         static readonly float nameRowTop = networkAssignRowTop - rowStep;
         static readonly float destinationNetworkRowTop = nameRowTop - rowStep;
         static readonly float destinationPortalRowTop = destinationNetworkRowTop - rowStep;
-        static readonly float defaultPortalRowTop = destinationPortalRowTop - rowStep;
+        static readonly float privatePortalRowTop = destinationPortalRowTop - rowStep;
+        static readonly float defaultPortalRowTop = privatePortalRowTop - rowStep;
         static readonly float firstColumnLeft = 0f + padding;
         static readonly float secondColumnLeft = firstColumnLeft + labelWidth + padding;
         // Great. Anyway, let's move on now..
@@ -78,6 +82,8 @@ namespace XPortal.UI
         private GameObject targetPortalDropdownUpDownKeyhint;
         private InputField portalNameInputField;
         private Toggle defaultPortalToggle;
+        private Toggle privatePortalToggle;
+        private Button okayButton;
         private Dropdown networkAssignmentDropdown;
         private Dropdown destinationNetworkDropdown;
 
@@ -93,6 +99,9 @@ namespace XPortal.UI
 
         private long selectedDestinationNetworkOwnerId;
         private bool canEditNetworkAssignment;
+        private bool canEditPortalFully;
+        private long personalNetworkOwnerId;
+        private bool readOnlyPrivatePortal;
 
         /// <summary>Piece <see cref="ZDOVars.s_creator"/>; personal network option uses this owner id (admin editing someone else's portal).</summary>
         private long pieceCreatorPlayerId;
@@ -239,12 +248,14 @@ namespace XPortal.UI
         #endregion
 
         #region Values
-        public void ConfigurePortal(KnownPortal portal, bool canEditNetwork)
+        public void ConfigurePortal(KnownPortal portal, bool canEditNetwork, bool canEditPortalFully)
         {
             InitialiseUI();
 
             thisPortal = portal;
             canEditNetworkAssignment = canEditNetwork;
+            this.canEditPortalFully = canEditPortalFully;
+            readOnlyPrivatePortal = portal.IsPrivate && !canEditPortalFully;
             pieceCreatorPlayerId = 0L;
             if (ZDOMan.instance != null)
             {
@@ -255,16 +266,62 @@ namespace XPortal.UI
                 }
             }
 
+            var localPlayerId = Player.m_localPlayer != null
+                ? Player.m_localPlayer.GetPlayerID()
+                : Game.instance.GetPlayerProfile().GetPlayerID();
+            personalNetworkOwnerId = pieceCreatorPlayerId != 0L ? pieceCreatorPlayerId : localPlayerId;
+
             portalNameInputField.text = portal.Name;
             selectedTargetId = portal.Target;
 
             defaultPortalToggle.isOn = thisPortal.IsDefaultPortal;
+            privatePortalToggle.isOn = thisPortal.IsPrivate;
+
+            privatePortalToggle.onValueChanged.RemoveAllListeners();
+            privatePortalToggle.onValueChanged.AddListener(OnPrivatePortalToggleChanged);
 
             PopulateNetworkAssignmentDropdown();
             PopulateDestinationNetworkDropdown();
             PopulateDestinationPortalDropdown();
 
+            ApplyReadOnlyState();
+
             Show();
+        }
+
+        private void ApplyReadOnlyState()
+        {
+            readOnlyPrivatePortal = thisPortal.IsPrivate && !canEditPortalFully;
+            var allowEdits = !readOnlyPrivatePortal;
+            portalNameInputField.interactable = allowEdits;
+            targetPortalDropdown.interactable = allowEdits;
+            destinationNetworkDropdown.interactable = allowEdits;
+            networkAssignmentDropdown.interactable = canEditNetworkAssignment && allowEdits;
+            defaultPortalToggle.interactable = allowEdits;
+            privatePortalToggle.interactable = canEditPortalFully && allowEdits;
+            if (okayButton != null)
+            {
+                okayButton.interactable = allowEdits;
+            }
+
+            var pingBtn = pingMapButtonObject != null ? pingMapButtonObject.GetComponent<Button>() : null;
+            if (pingBtn != null)
+            {
+                pingBtn.interactable = allowEdits && selectedTargetId != ZDOID.None;
+            }
+        }
+
+        private void OnPrivatePortalToggleChanged(bool isOn)
+        {
+            if (!canEditNetworkAssignment)
+            {
+                return;
+            }
+
+            if (isOn)
+            {
+                networkAssignmentDropdown.SetValueWithoutNotify(1);
+            }
         }
 
         private void PopulateNetworkAssignmentDropdown()
@@ -290,7 +347,11 @@ namespace XPortal.UI
             long personalNetworkOwnerId = pieceCreatorPlayerId != 0L ? pieceCreatorPlayerId : localPlayerId;
             networkAssignmentDropdown.options.Add(new Dropdown.OptionData(PortalNetwork.FormatNetworkLabel(personalNetworkOwnerId)));
 
-            if (thisPortal.NetworkOwnerPlayerId == 0L)
+            if (thisPortal.IsPrivate)
+            {
+                networkAssignmentDropdown.value = 1;
+            }
+            else if (thisPortal.NetworkOwnerPlayerId == 0L)
             {
                 networkAssignmentDropdown.value = 0;
             }
@@ -306,7 +367,10 @@ namespace XPortal.UI
 
         private void OnNetworkAssignmentDropdownValueChanged(Dropdown change)
         {
-            // Reserved for future validation
+            if (change.value == 0 && privatePortalToggle.isOn)
+            {
+                privatePortalToggle.SetIsOnWithoutNotify(false);
+            }
         }
 
         private long GetSubmittedNetworkOwnerPlayerId()
@@ -316,15 +380,22 @@ namespace XPortal.UI
                 return thisPortal.NetworkOwnerPlayerId;
             }
 
+            var localPlayerId = Player.m_localPlayer != null
+                ? Player.m_localPlayer.GetPlayerID()
+                : Game.instance.GetPlayerProfile().GetPlayerID();
+            var personalId = pieceCreatorPlayerId != 0L ? pieceCreatorPlayerId : localPlayerId;
+
+            if (privatePortalToggle.isOn)
+            {
+                return personalId;
+            }
+
             if (networkAssignmentDropdown.value == 0)
             {
                 return 0L;
             }
 
-            var localPlayerId = Player.m_localPlayer != null
-                ? Player.m_localPlayer.GetPlayerID()
-                : Game.instance.GetPlayerProfile().GetPlayerID();
-            return pieceCreatorPlayerId != 0L ? pieceCreatorPlayerId : localPlayerId;
+            return personalId;
         }
 
         private void PopulateDestinationNetworkDropdown()
@@ -333,7 +404,7 @@ namespace XPortal.UI
             destinationNetworkDropdown.ClearOptions();
             destinationNetworkIndexToOwnerId.Clear();
 
-            var ownerIds = new HashSet<long>();
+            var playerIds = new HashSet<long>();
             foreach (var p in KnownPortalsManager.Instance.GetList())
             {
                 if (p.Id == thisPortal.Id)
@@ -341,36 +412,33 @@ namespace XPortal.UI
                     continue;
                 }
 
-                ownerIds.Add(p.NetworkOwnerPlayerId);
+                if (p.NetworkOwnerPlayerId != 0L)
+                {
+                    playerIds.Add(p.NetworkOwnerPlayerId);
+                }
             }
 
-            var sorted = ownerIds.ToList();
-            sorted.Sort(CompareNetworkOwnerIds);
+            var sortedPlayerIds = playerIds.ToList();
+            sortedPlayerIds.Sort(ComparePlayerNetworkNames);
 
             var index = -1;
-            foreach (var ownerId in sorted)
+            destinationNetworkDropdown.options.Add(new Dropdown.OptionData(PortalNetwork.FormatNetworkLabel(0L)));
+            destinationNetworkIndexToOwnerId.Add(++index, 0L);
+
+            destinationNetworkDropdown.options.Add(new Dropdown.OptionData(PortalNetwork.FormatNetworkLabel(PortalNetwork.DestinationNetworkMyPrivateBucket)));
+            destinationNetworkIndexToOwnerId.Add(++index, PortalNetwork.DestinationNetworkMyPrivateBucket);
+
+            foreach (var ownerId in sortedPlayerIds)
             {
                 destinationNetworkDropdown.options.Add(new Dropdown.OptionData(PortalNetwork.FormatNetworkLabel(ownerId)));
                 destinationNetworkIndexToOwnerId.Add(++index, ownerId);
             }
 
-            if (sorted.Count == 0)
-            {
-                destinationNetworkDropdown.options.Add(new Dropdown.OptionData(Localization.instance.Localize("$hud_xportal_no_destinations")));
-                destinationNetworkIndexToOwnerId.Add(0, 0L);
-                destinationNetworkDropdown.value = 0;
-                selectedDestinationNetworkOwnerId = 0L;
-                ApplyDropdownStyle(destinationNetworkDropdown);
-                destinationNetworkDropdown.RefreshShownValue();
-                destinationNetworkDropdown.onValueChanged.AddListener(delegate { OnDestinationNetworkDropdownValueChanged(destinationNetworkDropdown); });
-                return;
-            }
-
-            selectedDestinationNetworkOwnerId = ResolveInitialDestinationNetworkOwnerId(sorted);
+            selectedDestinationNetworkOwnerId = ResolveInitialDestinationNetworkOwnerId(sortedPlayerIds);
             var selectIdx = 0;
-            for (var i = 0; i < sorted.Count; i++)
+            for (var i = 0; i < destinationNetworkDropdown.options.Count; i++)
             {
-                if (sorted[i] == selectedDestinationNetworkOwnerId)
+                if (destinationNetworkIndexToOwnerId.TryGetValue(i, out var oid) && oid == selectedDestinationNetworkOwnerId)
                 {
                     selectIdx = i;
                     break;
@@ -378,41 +446,47 @@ namespace XPortal.UI
             }
 
             destinationNetworkDropdown.value = selectIdx;
-            selectedDestinationNetworkOwnerId = destinationNetworkIndexToOwnerId[selectIdx];
+            if (destinationNetworkIndexToOwnerId.TryGetValue(selectIdx, out var resolved))
+            {
+                selectedDestinationNetworkOwnerId = resolved;
+            }
+
             ApplyDropdownStyle(destinationNetworkDropdown);
             destinationNetworkDropdown.RefreshShownValue();
             destinationNetworkDropdown.onValueChanged.AddListener(delegate { OnDestinationNetworkDropdownValueChanged(destinationNetworkDropdown); });
         }
 
-        private static int CompareNetworkOwnerIds(long a, long b)
+        private static int ComparePlayerNetworkNames(long a, long b)
         {
-            if (a == 0L && b != 0L)
-            {
-                return -1;
-            }
-
-            if (a != 0L && b == 0L)
-            {
-                return 1;
-            }
-
-            return a.CompareTo(b);
+            var la = PortalNetwork.FormatNetworkLabel(a);
+            var lb = PortalNetwork.FormatNetworkLabel(b);
+            return string.Compare(la, lb, StringComparison.OrdinalIgnoreCase);
         }
 
-        private long ResolveInitialDestinationNetworkOwnerId(List<long> sortedOwnerIds)
+        private long ResolveInitialDestinationNetworkOwnerId(List<long> sortedPlayerIds)
         {
             if (!thisPortal.HasTarget() || !KnownPortalsManager.Instance.ContainsId(thisPortal.Target))
             {
-                return sortedOwnerIds[0];
+                return 0L;
             }
 
             var targetPortal = KnownPortalsManager.Instance.GetKnownPortalById(thisPortal.Target);
-            if (sortedOwnerIds.Contains(targetPortal.NetworkOwnerPlayerId))
+            if (targetPortal.NetworkOwnerPlayerId == 0L)
+            {
+                return 0L;
+            }
+
+            if (targetPortal.IsPrivate && targetPortal.NetworkOwnerPlayerId == personalNetworkOwnerId)
+            {
+                return PortalNetwork.DestinationNetworkMyPrivateBucket;
+            }
+
+            if (!targetPortal.IsPrivate && sortedPlayerIds.Contains(targetPortal.NetworkOwnerPlayerId))
             {
                 return targetPortal.NetworkOwnerPlayerId;
             }
 
-            return sortedOwnerIds[0];
+            return 0L;
         }
 
         private void OnDestinationNetworkDropdownValueChanged(Dropdown change)
@@ -440,8 +514,32 @@ namespace XPortal.UI
             dropdownIndexToZDOIDMapping.Add(index, ZDOID.None);
 
             var portalsSorted = KnownPortalsManager.Instance.GetSortedList()
-                .Where(p => p.Id != thisPortal.Id && p.NetworkOwnerPlayerId == selectedDestinationNetworkOwnerId)
+                .Where(p => p.Id != thisPortal.Id)
+                .Where(p =>
+                {
+                    if (selectedDestinationNetworkOwnerId == 0L)
+                    {
+                        return p.NetworkOwnerPlayerId == 0L && !p.IsPrivate;
+                    }
+
+                    if (selectedDestinationNetworkOwnerId == PortalNetwork.DestinationNetworkMyPrivateBucket)
+                    {
+                        return p.NetworkOwnerPlayerId == personalNetworkOwnerId && p.IsPrivate;
+                    }
+
+                    return p.NetworkOwnerPlayerId == selectedDestinationNetworkOwnerId && !p.IsPrivate;
+                })
                 .ToList();
+
+            var localPlayerId = Player.m_localPlayer != null
+                ? Player.m_localPlayer.GetPlayerID()
+                : Game.instance.GetPlayerProfile().GetPlayerID();
+            if (!canEditPortalFully && !thisPortal.IsPrivate)
+            {
+                portalsSorted = portalsSorted
+                    .Where(p => !(p.IsPrivate && p.NetworkOwnerPlayerId == localPlayerId))
+                    .ToList();
+            }
 
             foreach (var portal in portalsSorted)
             {
@@ -481,7 +579,7 @@ namespace XPortal.UI
                 dropdownIndexToZDOIDMapping.Add(index, portal.Id);
             }
 
-            if (!dropdownIndexToZDOIDMapping.Values.Any(id => id == selectedTargetId))
+            if (!readOnlyPrivatePortal && !dropdownIndexToZDOIDMapping.Values.Any(id => id == selectedTargetId))
             {
                 targetPortalDropdown.value = 0;
                 selectedTargetId = ZDOID.None;
@@ -491,6 +589,7 @@ namespace XPortal.UI
             SetPingMapButtonActive(selectedTargetId != ZDOID.None);
 
             targetPortalDropdown.onValueChanged.AddListener(delegate { OnDropdownValueChanged(targetPortalDropdown); });
+            ApplyReadOnlyState();
         }
         #endregion
 
@@ -499,11 +598,18 @@ namespace XPortal.UI
         {
             selectedTargetId = dropdownIndexToZDOIDMapping[change.value];
             SetPingMapButtonActive(selectedTargetId != ZDOID.None);
+            ApplyReadOnlyState();
         }
 
         private void OnOkayButtonClicked()
         {
-            XPortal.PortalInfoSubmitted(thisPortal, portalNameInputField.text, selectedTargetId, defaultPortalToggle.isOn, GetSubmittedNetworkOwnerPlayerId());
+            global::XPortal.XPortal.PortalInfoSubmitted(
+                thisPortal,
+                portalNameInputField.text,
+                selectedTargetId,
+                defaultPortalToggle.isOn,
+                GetSubmittedNetworkOwnerPlayerId(),
+                privatePortalToggle.isOn);
             Hide();
         }
 
@@ -547,7 +653,7 @@ namespace XPortal.UI
                         anchorMax: new Vector2(0.5f, 0.5f),
                         position: new Vector2(0f, 0f),
                         width: mainPanelWidthMin,
-                        height: 440f,
+                        height: 496f,
                         draggable: false);
                 mainPanel.name = GO_MAINPANEL;
                 mainPanel.AddComponent<CanvasGroup>();
@@ -758,6 +864,45 @@ namespace XPortal.UI
                 AddGamepadHint(pingMapButtonObject, "JoyButtonY", KeyCode.None);
 
 
+                // Private portal label
+                var privatePortalLabelObject = GUIManager.Instance.CreateText(
+                        text: Localization.instance.Localize("$piece_portal_private"),
+                        parent: mainPanel.transform,
+                        anchorMin: new Vector2(0f, 1f),
+                        anchorMax: new Vector2(0f, 1f),
+                        position: new Vector2(firstColumnLeft, privatePortalRowTop),
+                        font: GUIManager.Instance.AveriaSerif,
+                        fontSize: 18,
+                        color: GUIManager.Instance.ValheimOrange,
+                        outline: true,
+                        outlineColor: Color.black,
+                        width: labelWidth,
+                        height: rowHeight,
+                        addContentSizeFitter: false);
+                privatePortalLabelObject.name = GO_PRIVATEPORTALLABEL;
+                privatePortalLabelObject.GetComponent<RectTransform>().pivot = new Vector2(0, 1);
+                privatePortalLabelObject.GetComponent<Text>().alignment = TextAnchor.MiddleLeft;
+                privatePortalLabelObject.GetComponent<Text>().horizontalOverflow = HorizontalWrapMode.Overflow;
+
+                var privatePortalCheckboxObject = GUIManager.Instance.CreateToggle(
+                    parent: mainPanel.transform,
+                    width: rowHeight,
+                    height: rowHeight);
+                privatePortalCheckboxObject.name = GO_PRIVATEPORTALCHECKBOX;
+
+                var privateExtraPadding = padding / 3;
+                var privatePortalCheckboxRt = privatePortalCheckboxObject.GetComponent<RectTransform>();
+                privatePortalCheckboxRt.pivot = new Vector2(0f, 1f);
+                privatePortalCheckboxRt.anchorMin = new Vector2(0f, 1f);
+                privatePortalCheckboxRt.anchorMax = new Vector2(0f, 1f);
+                privatePortalCheckboxRt.anchoredPosition = new Vector2(secondColumnLeft + privateExtraPadding, privatePortalRowTop - privateExtraPadding);
+
+                privatePortalToggle = privatePortalCheckboxObject.GetComponent<Toggle>();
+                privatePortalToggle.isOn = false;
+
+                AddGamepadHint(privatePortalCheckboxObject, "JoyLStick", KeyCode.None);
+
+
                 // Default Portal label
                 var defaultPortalLabelObject = GUIManager.Instance.CreateText(
                         text: Localization.instance.Localize("$piece_portal_defaultportal"), // "Default Portal"
@@ -811,6 +956,7 @@ namespace XPortal.UI
                         height: submitButtonHeight);
                 okayButtonObject.name = GO_OKAYBUTTON;
                 okayButtonObject.GetComponent<RectTransform>().pivot = new Vector2(1, 0);    // pivot bottom right
+                okayButton = okayButtonObject.GetComponent<Button>();
 
                 AddGamepadHint(okayButtonObject, "JoyButtonA", KeyCode.Return);
 
@@ -918,6 +1064,10 @@ namespace XPortal.UI
             targetPortalDropdown?.onValueChanged.RemoveAllListeners();
             networkAssignmentDropdown?.onValueChanged.RemoveAllListeners();
             destinationNetworkDropdown?.onValueChanged.RemoveAllListeners();
+            if (privatePortalToggle != null)
+            {
+                privatePortalToggle.onValueChanged.RemoveAllListeners();
+            }
 
             if (targetPortalDropdown)
                 GameObject.Destroy(targetPortalDropdown);

--- a/XPortal/UI/PortalConfigurationPanel.cs
+++ b/XPortal/UI/PortalConfigurationPanel.cs
@@ -276,6 +276,13 @@ namespace XPortal.UI
 
             defaultPortalToggle.isOn = thisPortal.IsDefaultPortal;
             privatePortalToggle.isOn = thisPortal.IsPrivate;
+            if (defaultPortalToggle.isOn)
+            {
+                privatePortalToggle.SetIsOnWithoutNotify(false);
+            }
+
+            defaultPortalToggle.onValueChanged.RemoveAllListeners();
+            defaultPortalToggle.onValueChanged.AddListener(OnDefaultPortalToggleChanged);
 
             privatePortalToggle.onValueChanged.RemoveAllListeners();
             privatePortalToggle.onValueChanged.AddListener(OnPrivatePortalToggleChanged);
@@ -298,7 +305,7 @@ namespace XPortal.UI
             destinationNetworkDropdown.interactable = allowEdits;
             networkAssignmentDropdown.interactable = canEditNetworkAssignment && allowEdits;
             defaultPortalToggle.interactable = allowEdits;
-            privatePortalToggle.interactable = canEditPortalFully && allowEdits;
+            privatePortalToggle.interactable = canEditPortalFully && allowEdits && !defaultPortalToggle.isOn;
             if (okayButton != null)
             {
                 okayButton.interactable = allowEdits;
@@ -311,8 +318,23 @@ namespace XPortal.UI
             }
         }
 
+        private void OnDefaultPortalToggleChanged(bool isOn)
+        {
+            if (isOn)
+            {
+                privatePortalToggle.SetIsOnWithoutNotify(false);
+            }
+
+            ApplyReadOnlyState();
+        }
+
         private void OnPrivatePortalToggleChanged(bool isOn)
         {
+            if (isOn)
+            {
+                defaultPortalToggle.SetIsOnWithoutNotify(false);
+            }
+
             if (!canEditNetworkAssignment)
             {
                 return;
@@ -385,7 +407,7 @@ namespace XPortal.UI
                 : Game.instance.GetPlayerProfile().GetPlayerID();
             var personalId = pieceCreatorPlayerId != 0L ? pieceCreatorPlayerId : localPlayerId;
 
-            if (privatePortalToggle.isOn)
+            if (privatePortalToggle.isOn && !defaultPortalToggle.isOn)
             {
                 return personalId;
             }
@@ -609,7 +631,7 @@ namespace XPortal.UI
                 selectedTargetId,
                 defaultPortalToggle.isOn,
                 GetSubmittedNetworkOwnerPlayerId(),
-                privatePortalToggle.isOn);
+                privatePortalToggle.isOn && !defaultPortalToggle.isOn);
             Hide();
         }
 
@@ -1067,6 +1089,11 @@ namespace XPortal.UI
             if (privatePortalToggle != null)
             {
                 privatePortalToggle.onValueChanged.RemoveAllListeners();
+            }
+
+            if (defaultPortalToggle != null)
+            {
+                defaultPortalToggle.onValueChanged.RemoveAllListeners();
             }
 
             if (targetPortalDropdown)

--- a/XPortal/UI/PortalConfigurationPanel.cs
+++ b/XPortal/UI/PortalConfigurationPanel.cs
@@ -29,6 +29,8 @@ namespace XPortal.UI
         internal const string GO_DESTINATIONLABEL = Info.Name + "_DestinationHeader";
         internal const string GO_DESTINATIONDROPDOWN = Info.Name + "_DestinationDropdown";
         internal const string GO_DESTINATIONGAMEPADHINT = Info.Name + "_DestinationGamepadHint";
+        internal const string GO_NETWORKASSIGNLISTNAVHINT = Info.Name + "_NetworkAssignListNavHint";
+        internal const string GO_DESTINATIONNETWORKLISTNAVHINT = Info.Name + "_DestinationNetworkListNavHint";
         internal const string GO_PINGMAPBUTTON = Info.Name + "_PingMapButton";
         internal const string GO_DEFAULTPORTALLABEL = Info.Name + "_DefaultPortalHeader";
         internal const string GO_DEFAULTPORTALCHECKBOX = Info.Name + "_DefaultPortalCheckbox";
@@ -82,7 +84,7 @@ namespace XPortal.UI
         private GameObject pingMapButtonObject;
         private GameObject targetPortalDropdownObject;
         private Dropdown targetPortalDropdown;
-        private GameObject targetPortalDropdownUpDownKeyhint;
+        private readonly List<GameObject> dropdownListNavHints = new List<GameObject>();
         private InputField portalNameInputField;
         private Toggle defaultPortalToggle;
         private Toggle privatePortalToggle;
@@ -116,9 +118,14 @@ namespace XPortal.UI
         private ButtonConfig uiDropdownScrollDownButton;
         #endregion
 
-        public bool DropdownExpanded = false;
+        // Open list, if any (managed dropdowns only).
+        public Dropdown ExpandedDropdown { get; private set; }
+
+        public bool DropdownExpanded => ExpandedDropdown != null;
 
         private static ScrollRect listScrollCache;
+
+        private Dropdown lastSyncedScrollDropdown;
 
         private int lastSyncedListScroll = int.MinValue;
 
@@ -148,6 +155,31 @@ namespace XPortal.UI
         private PortalConfigurationPanel()
         {
             dropdownIndexToZDOIDMapping = new Dictionary<int, ZDOID>();
+        }
+
+        internal static bool IsManagedDropdown(Dropdown d)
+        {
+            return d != null && IsManagedDropdownName(d.name);
+        }
+
+        internal static bool IsManagedDropdownName(string name)
+        {
+            return name == GO_DESTINATIONDROPDOWN
+                || name == GO_NETWORKASSIGNDROPDOWN
+                || name == GO_DESTINATIONNETWORKDROPDOWN;
+        }
+
+        internal void SetExpandedDropdown(Dropdown d)
+        {
+            ExpandedDropdown = d;
+        }
+
+        internal void ClearExpandedDropdownIf(Dropdown d)
+        {
+            if (ExpandedDropdown == d)
+            {
+                ExpandedDropdown = null;
+            }
         }
 
         internal static void QueueListScroll(Dropdown dropdown)
@@ -274,7 +306,7 @@ namespace XPortal.UI
 
         private static void FocusListRow(Dropdown dropdown, int rowIndex)
         {
-            if (Instance == null || !Instance.DropdownExpanded || dropdown == null)
+            if (Instance == null || Instance.ExpandedDropdown != dropdown || dropdown == null)
             {
                 return;
             }
@@ -341,6 +373,7 @@ namespace XPortal.UI
             listScrollCache = null;
             if (Instance != null)
             {
+                Instance.lastSyncedScrollDropdown = null;
                 Instance.lastSyncedListScroll = int.MinValue;
                 Instance.listNavNextTime = 0f;
             }
@@ -348,19 +381,20 @@ namespace XPortal.UI
 
         internal void SyncListScroll()
         {
-            if (!DropdownExpanded || targetPortalDropdown == null)
+            if (ExpandedDropdown == null)
             {
                 return;
             }
 
-            int v = targetPortalDropdown.value;
-            if (v == lastSyncedListScroll)
+            int v = ExpandedDropdown.value;
+            if (ExpandedDropdown == lastSyncedScrollDropdown && v == lastSyncedListScroll)
             {
                 return;
             }
 
+            lastSyncedScrollDropdown = ExpandedDropdown;
             lastSyncedListScroll = v;
-            ApplyListScroll(targetPortalDropdown, rebuildLayout: true);
+            ApplyListScroll(ExpandedDropdown, rebuildLayout: true);
         }
 
         private static MethodInfo scrollRectUpdateBounds;
@@ -608,9 +642,18 @@ namespace XPortal.UI
 
         public void HandleInput()
         {
-            if (targetPortalDropdownUpDownKeyhint)
+            bool gamepad = ZInput.IsGamepadActive();
+            for (int i = 0; i < dropdownListNavHints.Count; i++)
             {
-                targetPortalDropdownUpDownKeyhint.SetActive(ZInput.IsGamepadActive());
+                GameObject h = dropdownListNavHints[i];
+                if (!h)
+                {
+                    continue;
+                }
+
+                Dropdown owner = h.transform.parent != null ? h.transform.parent.GetComponent<Dropdown>() : null;
+                bool show = gamepad && owner != null && ExpandedDropdown == owner;
+                h.SetActive(show);
             }
 
             ProcessListNav();
@@ -618,7 +661,7 @@ namespace XPortal.UI
 
         private void ProcessListNav()
         {
-            if (!DropdownExpanded || targetPortalDropdown == null)
+            if (ExpandedDropdown == null)
             {
                 listNavNextTime = 0f;
                 return;
@@ -711,19 +754,25 @@ namespace XPortal.UI
 
         private void BumpDropdown(bool up)
         {
-            int max = targetPortalDropdown.options.Count - 1;
+            Dropdown dd = ExpandedDropdown;
+            if (dd == null)
+            {
+                return;
+            }
+
+            int max = dd.options.Count - 1;
             if (max < 0)
             {
                 return;
             }
 
-            int newVal = Mathf.Clamp(targetPortalDropdown.value + (up ? -1 : 1), 0, max);
-            if (newVal == targetPortalDropdown.value)
+            int newVal = Mathf.Clamp(dd.value + (up ? -1 : 1), 0, max);
+            if (newVal == dd.value)
             {
                 return;
             }
 
-            targetPortalDropdown.value = newVal;
+            dd.value = newVal;
         }
 
         private void SetPingMapButtonActive(bool active)
@@ -1288,6 +1337,8 @@ namespace XPortal.UI
                 networkAssignmentDropdown.GetComponent<RectTransform>().pivot = new Vector2(0, 1);
                 ApplyDropdownStyle(networkAssignmentDropdown);
 
+                AddGamepadHint(networkAssignDropdownObject, "JoyButtonY", KeyCode.None);
+                AttachDropdownListNavHint(networkAssignDropdownObject, GO_NETWORKASSIGNLISTNAVHINT);
 
                 // Portal name label
                 var portalNameLabelObject = GUIManager.Instance.CreateText(
@@ -1361,6 +1412,8 @@ namespace XPortal.UI
                 destinationNetworkDropdown.GetComponent<RectTransform>().pivot = new Vector2(0, 1);
                 ApplyDropdownStyle(destinationNetworkDropdown);
 
+                AddGamepadHint(destinationNetworkDropdownObject, "JoyLBumper", KeyCode.None);
+                AttachDropdownListNavHint(destinationNetworkDropdownObject, GO_DESTINATIONNETWORKLISTNAVHINT);
 
                 // Target portal label
                 var targetPortalLabelObject = GUIManager.Instance.CreateText(
@@ -1400,23 +1453,7 @@ namespace XPortal.UI
                 ApplyDropdownStyle(targetPortalDropdown);
 
                 AddGamepadHint(targetPortalDropdownObject, "JoyButtonX", KeyCode.None);
-
-
-                // Target portal dropdown up/down keyhint image
-                // This is shown on the *left* side of the dropdown
-                targetPortalDropdownUpDownKeyhint = new GameObject(GO_DESTINATIONGAMEPADHINT, typeof(RectTransform), typeof(Image));
-                targetPortalDropdownUpDownKeyhint.transform.SetParent(targetPortalDropdownObject.transform, worldPositionStays: false);
-
-                var targetPortalDropdownUpDownKeyhintRt = targetPortalDropdownUpDownKeyhint.GetComponent<RectTransform>();
-                targetPortalDropdownUpDownKeyhintRt.pivot = new Vector2(1, 0.5f); // pivot middle right
-                targetPortalDropdownUpDownKeyhintRt.anchorMin = new Vector2(0, 0.5f); // anchor middle left
-                targetPortalDropdownUpDownKeyhintRt.anchorMax = new Vector2(0, 0.5f);
-                targetPortalDropdownUpDownKeyhintRt.sizeDelta = new Vector2(36, 36);
-                targetPortalDropdownUpDownKeyhintRt.anchoredPosition = new Vector2(10, 0);
-
-                var targetPortalDropdownUpDownKeyhintImg = targetPortalDropdownUpDownKeyhint.GetComponent<Image>();
-                targetPortalDropdownUpDownKeyhintImg.sprite = GUIManager.Instance.GetSprite("dpad_updown");
-
+                AttachDropdownListNavHint(targetPortalDropdownObject, GO_DESTINATIONGAMEPADHINT);
 
                 // Ping on Map button
                 pingMapButtonObject = GUIManager.Instance.CreateButton(
@@ -1430,7 +1467,7 @@ namespace XPortal.UI
                 pingMapButtonObject.name = GO_PINGMAPBUTTON;
                 pingMapButtonObject.GetComponent<RectTransform>().pivot = new Vector2(0, 1);    // pivot top left
 
-                AddGamepadHint(pingMapButtonObject, "JoyButtonY", KeyCode.None);
+                AddGamepadHint(pingMapButtonObject, "JoyRBumper", KeyCode.None);
 
 
                 // Private portal label
@@ -1469,7 +1506,7 @@ namespace XPortal.UI
                 privatePortalToggle = privatePortalCheckboxObject.GetComponent<Toggle>();
                 privatePortalToggle.isOn = false;
 
-                AddGamepadHint(privatePortalCheckboxObject, "JoyLStick", KeyCode.None);
+                AddGamepadHint(privatePortalCheckboxObject, "JoyRStick", KeyCode.None);
 
 
                 // Default Portal label
@@ -1628,6 +1665,20 @@ namespace XPortal.UI
             uiInputHint.m_gamepadHint = goGamepadHint;
         }
 
+        private void AttachDropdownListNavHint(GameObject dropdownObject, string hintObjectName)
+        {
+            var hint = new GameObject(hintObjectName, typeof(RectTransform), typeof(Image));
+            hint.transform.SetParent(dropdownObject.transform, false);
+            RectTransform rt = hint.GetComponent<RectTransform>();
+            rt.pivot = new Vector2(1f, 0.5f);
+            rt.anchorMin = new Vector2(0f, 0.5f);
+            rt.anchorMax = new Vector2(0f, 0.5f);
+            rt.sizeDelta = new Vector2(36f, 36f);
+            rt.anchoredPosition = new Vector2(10f, 0f);
+            hint.GetComponent<Image>().sprite = GUIManager.Instance.GetSprite("dpad_updown");
+            dropdownListNavHints.Add(hint);
+        }
+
         private GameObject CreateGamepadHint(string buttonName)
         {
             var goGamepadHint = new GameObject("gamepad_hint", typeof(RectTransform), typeof(TextMeshProUGUI));
@@ -1671,7 +1722,11 @@ namespace XPortal.UI
                 GameObject.Destroy(targetPortalDropdown);
 
             if (mainPanel)
+            {
                 GameObject.Destroy(mainPanel);
+            }
+
+            dropdownListNavHints.Clear();
         }
     }
 }

--- a/XPortal/UI/PortalConfigurationPanel.cs
+++ b/XPortal/UI/PortalConfigurationPanel.cs
@@ -1605,21 +1605,17 @@ namespace XPortal.UI
             Transform contentTransform = dropdown.template.Find("Viewport/Content");
             if (contentTransform != null)
             {
+                Transform oldSpacer = contentTransform.Find(ListBottomSpacerName);
+                if (oldSpacer != null)
+                {
+                    GameObject.Destroy(oldSpacer.gameObject);
+                }
+
                 VerticalLayoutGroup contentVlg = contentTransform.GetComponent<VerticalLayoutGroup>();
                 if (contentVlg != null)
                 {
-                    contentVlg.padding.bottom = Mathf.Max(contentVlg.padding.bottom, 20);
-                }
-
-                if (contentTransform.Find(ListBottomSpacerName) == null)
-                {
-                    GameObject spacerGo = new GameObject(ListBottomSpacerName, typeof(RectTransform), typeof(LayoutElement));
-                    spacerGo.transform.SetParent(contentTransform, false);
-                    LayoutElement spacerLe = spacerGo.GetComponent<LayoutElement>();
-                    spacerLe.minHeight = ListBottomSpacerH;
-                    spacerLe.preferredHeight = ListBottomSpacerH;
-                    spacerLe.flexibleHeight = 0f;
-                    spacerGo.transform.SetAsLastSibling();
+                    int desiredBottom = 20 + Mathf.RoundToInt(ListBottomSpacerH);
+                    contentVlg.padding.bottom = Mathf.Max(contentVlg.padding.bottom, desiredBottom);
                 }
             }
 
@@ -1675,7 +1671,9 @@ namespace XPortal.UI
             rt.anchorMax = new Vector2(0f, 0.5f);
             rt.sizeDelta = new Vector2(36f, 36f);
             rt.anchoredPosition = new Vector2(10f, 0f);
-            hint.GetComponent<Image>().sprite = GUIManager.Instance.GetSprite("dpad_updown");
+            var img = hint.GetComponent<Image>();
+            img.sprite = GUIManager.Instance.GetSprite("dpad_updown");
+            img.raycastTarget = false;
             dropdownListNavHints.Add(hint);
         }
 
@@ -1690,6 +1688,7 @@ namespace XPortal.UI
             textMesh.text = $"$KEY_{buttonName}";
             textMesh.fontSize = 18;
             textMesh.alignment = TextAlignmentOptions.Center;
+            textMesh.raycastTarget = false;
             Localization.instance.textMeshStrings[textMesh] = textMesh.text;
 
             var rt = goGamepadHint.GetComponent<RectTransform>();

--- a/XPortal/UI/PortalConfigurationPanel.cs
+++ b/XPortal/UI/PortalConfigurationPanel.cs
@@ -619,8 +619,8 @@ namespace XPortal.UI
         #region Input
         internal void AddInputs()
         {
-            uiDropdownScrollUpButton = AddInput("XPortal_DropdownScrollUp", "Dropdown scroll up", InputManager.GamepadButton.DPadUp, KeyCode.UpArrow);
-            uiDropdownScrollDownButton = AddInput("XPortal_DropdownScrollDown", "Dropdown scroll down", InputManager.GamepadButton.DPadDown, KeyCode.DownArrow);
+            uiDropdownScrollUpButton = AddInput("XPortal_DropdownScrollUp", "$settings_dropdown_scrollup", InputManager.GamepadButton.DPadUp, KeyCode.UpArrow);
+            uiDropdownScrollDownButton = AddInput("XPortal_DropdownScrollDown", "$settings_dropdown_scrolldown", InputManager.GamepadButton.DPadDown, KeyCode.DownArrow);
         }
 
         private ButtonConfig AddInput(string name, string hintToken, InputManager.GamepadButton gamepadButton, KeyCode key)
@@ -636,7 +636,9 @@ namespace XPortal.UI
                 RepeatDelay = 1000f,
                 BlockOtherInputs = true,
             };
+            
             InputManager.Instance.AddButton(Info.GUID, newButtonConfig);
+            
             return newButtonConfig;
         }
 

--- a/XPortal/UI/PortalConfigurationPanel.cs
+++ b/XPortal/UI/PortalConfigurationPanel.cs
@@ -492,13 +492,18 @@ namespace XPortal.UI
                 return 0L;
             }
 
+            var localPlayerId = Player.m_localPlayer != null
+                ? Player.m_localPlayer.GetPlayerID()
+                : Game.instance.GetPlayerProfile().GetPlayerID();
+
             var targetPortal = KnownPortalsManager.Instance.GetKnownPortalById(thisPortal.Target);
             if (targetPortal.NetworkOwnerPlayerId == 0L)
             {
                 return 0L;
             }
 
-            if (targetPortal.IsPrivate && targetPortal.NetworkOwnerPlayerId == personalNetworkOwnerId)
+            // Destination networks are always from the local user's perspective ("My Private" = this player's privates).
+            if (targetPortal.IsPrivate && targetPortal.NetworkOwnerPlayerId == localPlayerId)
             {
                 return PortalNetwork.DestinationNetworkMyPrivateBucket;
             }
@@ -535,6 +540,10 @@ namespace XPortal.UI
             targetPortalDropdown.value = index;
             dropdownIndexToZDOIDMapping.Add(index, ZDOID.None);
 
+            var localPlayerId = Player.m_localPlayer != null
+                ? Player.m_localPlayer.GetPlayerID()
+                : Game.instance.GetPlayerProfile().GetPlayerID();
+
             var portalsSorted = KnownPortalsManager.Instance.GetSortedList()
                 .Where(p => p.Id != thisPortal.Id)
                 .Where(p =>
@@ -546,22 +555,12 @@ namespace XPortal.UI
 
                     if (selectedDestinationNetworkOwnerId == PortalNetwork.DestinationNetworkMyPrivateBucket)
                     {
-                        return p.NetworkOwnerPlayerId == personalNetworkOwnerId && p.IsPrivate;
+                        return p.NetworkOwnerPlayerId == localPlayerId && p.IsPrivate;
                     }
 
                     return p.NetworkOwnerPlayerId == selectedDestinationNetworkOwnerId && !p.IsPrivate;
                 })
                 .ToList();
-
-            var localPlayerId = Player.m_localPlayer != null
-                ? Player.m_localPlayer.GetPlayerID()
-                : Game.instance.GetPlayerProfile().GetPlayerID();
-            if (!canEditPortalFully && !thisPortal.IsPrivate)
-            {
-                portalsSorted = portalsSorted
-                    .Where(p => !(p.IsPrivate && p.NetworkOwnerPlayerId == localPlayerId))
-                    .ToList();
-            }
 
             foreach (var portal in portalsSorted)
             {

--- a/XPortal/UI/PortalConfigurationPanel.cs
+++ b/XPortal/UI/PortalConfigurationPanel.cs
@@ -3,6 +3,7 @@ using Jotunn.Configs;
 using Jotunn.Managers;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -29,6 +30,10 @@ namespace XPortal.UI
         internal const string GO_DEFAULTPORTALCHECKBOX = Mod.Info.Name + "_DefaultPortalCheckbox";
         internal const string GO_OKAYBUTTON = Mod.Info.Name + "_OkayButton";
         internal const string GO_CANCELBUTTON = Mod.Info.Name + "_CancelButton";
+        internal const string GO_NETWORKASSIGNLABEL = Mod.Info.Name + "_NetworkAssignHeader";
+        internal const string GO_NETWORKASSIGNDROPDOWN = Mod.Info.Name + "_NetworkAssignDropdown";
+        internal const string GO_DESTINATIONNETWORKLABEL = Mod.Info.Name + "_DestinationNetworkHeader";
+        internal const string GO_DESTINATIONNETWORKDROPDOWN = Mod.Info.Name + "_DestinationNetworkDropdown";
 
         #region Pain
         // Creating the UI was incredibly painful. I will never change the layout again. Ever.
@@ -55,9 +60,12 @@ namespace XPortal.UI
         static readonly float submitButtonHeight = 48f;
         static readonly float inputShortWidth = 460f;
         static readonly float inputLongWidth = inputShortWidth + padding + buttonWidth;
-        static readonly float firstRowTop = -60f - padding;
-        static readonly float secondRowTop = firstRowTop - rowHeight - padding;
-        static readonly float thirdRowTop = secondRowTop - rowHeight - padding;
+        static readonly float rowStep = rowHeight + padding;
+        static readonly float networkAssignRowTop = -60f - padding;
+        static readonly float nameRowTop = networkAssignRowTop - rowStep;
+        static readonly float destinationNetworkRowTop = nameRowTop - rowStep;
+        static readonly float destinationPortalRowTop = destinationNetworkRowTop - rowStep;
+        static readonly float defaultPortalRowTop = destinationPortalRowTop - rowStep;
         static readonly float firstColumnLeft = 0f + padding;
         static readonly float secondColumnLeft = firstColumnLeft + labelWidth + padding;
         // Great. Anyway, let's move on now..
@@ -70,15 +78,24 @@ namespace XPortal.UI
         private GameObject targetPortalDropdownUpDownKeyhint;
         private InputField portalNameInputField;
         private Toggle defaultPortalToggle;
+        private Dropdown networkAssignmentDropdown;
+        private Dropdown destinationNetworkDropdown;
 
         // A look-up list to find the portal ZDOID by dropdown list index
         private readonly Dictionary<int, ZDOID> dropdownIndexToZDOIDMapping;
+        private readonly Dictionary<int, long> destinationNetworkIndexToOwnerId = new Dictionary<int, long>();
 
         // The KnownPortal being configured
         private KnownPortal thisPortal;
 
         // The ZDOID of the target that was selected in the dropdown
         private ZDOID selectedTargetId;
+
+        private long selectedDestinationNetworkOwnerId;
+        private bool canEditNetworkAssignment;
+
+        /// <summary>Piece <see cref="ZDOVars.s_creator"/>; personal network option uses this owner id (admin editing someone else's portal).</summary>
+        private long pieceCreatorPlayerId;
 
         #region Input Button Configs
         private ButtonConfig uiDropdownScrollUpButton;
@@ -216,69 +233,229 @@ namespace XPortal.UI
             pingMapButtonObject.SetActive(active);
 
             var mainPanelRT = mainPanel.GetComponent<RectTransform>();
-            float dropdownWidth = (active ? inputShortWidth : inputLongWidth) - mainPanelRT.rect.width;
+            var dropdownWidth = (active ? inputShortWidth : inputLongWidth) - mainPanelRT.rect.width;
             targetPortalDropdownObject.GetComponent<RectTransform>().sizeDelta = new Vector2(dropdownWidth, rowHeight);
         }
         #endregion
 
         #region Values
-        public void ConfigurePortal(KnownPortal portal)
+        public void ConfigurePortal(KnownPortal portal, bool canEditNetwork)
         {
             InitialiseUI();
-            
+
             thisPortal = portal;
+            canEditNetworkAssignment = canEditNetwork;
+            pieceCreatorPlayerId = 0L;
+            if (ZDOMan.instance != null)
+            {
+                var portalZdo = ZDOMan.instance.GetZDO(portal.Id);
+                if (portalZdo != null)
+                {
+                    pieceCreatorPlayerId = portalZdo.GetLong(ZDOVars.s_creator);
+                }
+            }
+
             portalNameInputField.text = portal.Name;
             selectedTargetId = portal.Target;
 
             defaultPortalToggle.isOn = thisPortal.IsDefaultPortal;
 
-            PopulateDropdown();
+            PopulateNetworkAssignmentDropdown();
+            PopulateDestinationNetworkDropdown();
+            PopulateDestinationPortalDropdown();
 
             Show();
         }
 
-        private void PopulateDropdown()
+        private void PopulateNetworkAssignmentDropdown()
         {
-            // Remove any listeners so they don't get all upset
-            targetPortalDropdown.onValueChanged.RemoveAllListeners();
+            networkAssignmentDropdown.onValueChanged.RemoveAllListeners();
+            networkAssignmentDropdown.ClearOptions();
 
-            // Forget what we know
-            targetPortalDropdown.ClearOptions();
-            dropdownIndexToZDOIDMapping.Clear();
-
-            int index = -1;
-
-            // Add "None" option at index `0`
-            var strNone = Localization.instance.Localize("$piece_portal_target_none"); // "(None)"
-            targetPortalDropdown.options.Insert(++index, new Dropdown.OptionData(strNone));
-            targetPortalDropdown.value = index;
-            dropdownIndexToZDOIDMapping.Add(index, ZDOID.None);
-
-            // Get all KnownPortals, sorted by Name
-            var portalsSorted = KnownPortalsManager.Instance.GetSortedList();
-
-            foreach (var portal in portalsSorted)
+            if (!canEditNetworkAssignment)
             {
-                // Skip the one we're currently interacting with
-                if (portal.Id == thisPortal.Id)
+                networkAssignmentDropdown.options.Add(new Dropdown.OptionData(PortalNetwork.FormatNetworkLabel(thisPortal.NetworkOwnerPlayerId)));
+                networkAssignmentDropdown.value = 0;
+                networkAssignmentDropdown.interactable = false;
+                ApplyDropdownStyle(networkAssignmentDropdown);
+                networkAssignmentDropdown.RefreshShownValue();
+                return;
+            }
+
+            networkAssignmentDropdown.interactable = true;
+            networkAssignmentDropdown.options.Add(new Dropdown.OptionData(PortalNetwork.FormatNetworkLabel(0L)));
+            var localPlayerId = Player.m_localPlayer != null
+                ? Player.m_localPlayer.GetPlayerID()
+                : Game.instance.GetPlayerProfile().GetPlayerID();
+            long personalNetworkOwnerId = pieceCreatorPlayerId != 0L ? pieceCreatorPlayerId : localPlayerId;
+            networkAssignmentDropdown.options.Add(new Dropdown.OptionData(PortalNetwork.FormatNetworkLabel(personalNetworkOwnerId)));
+
+            if (thisPortal.NetworkOwnerPlayerId == 0L)
+            {
+                networkAssignmentDropdown.value = 0;
+            }
+            else
+            {
+                networkAssignmentDropdown.value = 1;
+            }
+
+            ApplyDropdownStyle(networkAssignmentDropdown);
+            networkAssignmentDropdown.RefreshShownValue();
+            networkAssignmentDropdown.onValueChanged.AddListener(delegate { OnNetworkAssignmentDropdownValueChanged(networkAssignmentDropdown); });
+        }
+
+        private void OnNetworkAssignmentDropdownValueChanged(Dropdown change)
+        {
+            // Reserved for future validation
+        }
+
+        private long GetSubmittedNetworkOwnerPlayerId()
+        {
+            if (!canEditNetworkAssignment)
+            {
+                return thisPortal.NetworkOwnerPlayerId;
+            }
+
+            if (networkAssignmentDropdown.value == 0)
+            {
+                return 0L;
+            }
+
+            var localPlayerId = Player.m_localPlayer != null
+                ? Player.m_localPlayer.GetPlayerID()
+                : Game.instance.GetPlayerProfile().GetPlayerID();
+            return pieceCreatorPlayerId != 0L ? pieceCreatorPlayerId : localPlayerId;
+        }
+
+        private void PopulateDestinationNetworkDropdown()
+        {
+            destinationNetworkDropdown.onValueChanged.RemoveAllListeners();
+            destinationNetworkDropdown.ClearOptions();
+            destinationNetworkIndexToOwnerId.Clear();
+
+            var ownerIds = new HashSet<long>();
+            foreach (var p in KnownPortalsManager.Instance.GetList())
+            {
+                if (p.Id == thisPortal.Id)
                 {
                     continue;
                 }
 
-                // Get portal name
-                string portalName = portal.Name;
+                ownerIds.Add(p.NetworkOwnerPlayerId);
+            }
 
+            var sorted = ownerIds.ToList();
+            sorted.Sort(CompareNetworkOwnerIds);
+
+            var index = -1;
+            foreach (var ownerId in sorted)
+            {
+                destinationNetworkDropdown.options.Add(new Dropdown.OptionData(PortalNetwork.FormatNetworkLabel(ownerId)));
+                destinationNetworkIndexToOwnerId.Add(++index, ownerId);
+            }
+
+            if (sorted.Count == 0)
+            {
+                destinationNetworkDropdown.options.Add(new Dropdown.OptionData(Localization.instance.Localize("$hud_xportal_no_destinations")));
+                destinationNetworkIndexToOwnerId.Add(0, 0L);
+                destinationNetworkDropdown.value = 0;
+                selectedDestinationNetworkOwnerId = 0L;
+                ApplyDropdownStyle(destinationNetworkDropdown);
+                destinationNetworkDropdown.RefreshShownValue();
+                destinationNetworkDropdown.onValueChanged.AddListener(delegate { OnDestinationNetworkDropdownValueChanged(destinationNetworkDropdown); });
+                return;
+            }
+
+            selectedDestinationNetworkOwnerId = ResolveInitialDestinationNetworkOwnerId(sorted);
+            var selectIdx = 0;
+            for (var i = 0; i < sorted.Count; i++)
+            {
+                if (sorted[i] == selectedDestinationNetworkOwnerId)
+                {
+                    selectIdx = i;
+                    break;
+                }
+            }
+
+            destinationNetworkDropdown.value = selectIdx;
+            selectedDestinationNetworkOwnerId = destinationNetworkIndexToOwnerId[selectIdx];
+            ApplyDropdownStyle(destinationNetworkDropdown);
+            destinationNetworkDropdown.RefreshShownValue();
+            destinationNetworkDropdown.onValueChanged.AddListener(delegate { OnDestinationNetworkDropdownValueChanged(destinationNetworkDropdown); });
+        }
+
+        private static int CompareNetworkOwnerIds(long a, long b)
+        {
+            if (a == 0L && b != 0L)
+            {
+                return -1;
+            }
+
+            if (a != 0L && b == 0L)
+            {
+                return 1;
+            }
+
+            return a.CompareTo(b);
+        }
+
+        private long ResolveInitialDestinationNetworkOwnerId(List<long> sortedOwnerIds)
+        {
+            if (!thisPortal.HasTarget() || !KnownPortalsManager.Instance.ContainsId(thisPortal.Target))
+            {
+                return sortedOwnerIds[0];
+            }
+
+            var targetPortal = KnownPortalsManager.Instance.GetKnownPortalById(thisPortal.Target);
+            if (sortedOwnerIds.Contains(targetPortal.NetworkOwnerPlayerId))
+            {
+                return targetPortal.NetworkOwnerPlayerId;
+            }
+
+            return sortedOwnerIds[0];
+        }
+
+        private void OnDestinationNetworkDropdownValueChanged(Dropdown change)
+        {
+            if (destinationNetworkIndexToOwnerId.Count == 0)
+            {
+                return;
+            }
+
+            selectedDestinationNetworkOwnerId = destinationNetworkIndexToOwnerId[change.value];
+            PopulateDestinationPortalDropdown();
+        }
+
+        private void PopulateDestinationPortalDropdown()
+        {
+            targetPortalDropdown.onValueChanged.RemoveAllListeners();
+            targetPortalDropdown.ClearOptions();
+            dropdownIndexToZDOIDMapping.Clear();
+
+            var index = -1;
+
+            var strNone = Localization.instance.Localize("$piece_portal_target_none");
+            targetPortalDropdown.options.Insert(++index, new Dropdown.OptionData(strNone));
+            targetPortalDropdown.value = index;
+            dropdownIndexToZDOIDMapping.Add(index, ZDOID.None);
+
+            var portalsSorted = KnownPortalsManager.Instance.GetSortedList()
+                .Where(p => p.Id != thisPortal.Id && p.NetworkOwnerPlayerId == selectedDestinationNetworkOwnerId)
+                .ToList();
+
+            foreach (var portal in portalsSorted)
+            {
+                var portalName = portal.Name;
                 if (string.IsNullOrEmpty(portalName))
                 {
-                    portalName = Localization.instance.Localize("$piece_portal_tag_none"); // "(No Name)"
+                    portalName = Localization.instance.Localize("$piece_portal_tag_none");
                 }
 
-                // Calculate portal distance
                 var distanceTag = string.Empty;
                 if (!XPortalConfig.Instance.Server.HidePortalDistance)
                 {
                     float distance = (int)Vector3.Distance(thisPortal.Location, portal.Location);
-                    string strDistance = string.Format("{0} m", distance.ToString());
+                    var strDistance = string.Format("{0} m", distance.ToString());
                     if (distance >= 1000)
                     {
                         strDistance = string.Format("{0:0.0} km", distance / 1000);
@@ -294,17 +471,20 @@ namespace XPortal.UI
                 }
 
                 var option = new Dropdown.OptionData($"{colourTag}{portalName}{distanceTag}");
-
-                // Insert at the next index
                 targetPortalDropdown.options.Insert(++index, option);
 
-                // Select it in the list if this is the current target
                 if (portal.Id == selectedTargetId)
                 {
                     targetPortalDropdown.value = index;
                 }
 
                 dropdownIndexToZDOIDMapping.Add(index, portal.Id);
+            }
+
+            if (!dropdownIndexToZDOIDMapping.Values.Any(id => id == selectedTargetId))
+            {
+                targetPortalDropdown.value = 0;
+                selectedTargetId = ZDOID.None;
             }
 
             targetPortalDropdown.RefreshShownValue();
@@ -323,7 +503,7 @@ namespace XPortal.UI
 
         private void OnOkayButtonClicked()
         {
-            XPortal.PortalInfoSubmitted(thisPortal, portalNameInputField.text, selectedTargetId, defaultPortalToggle.isOn);
+            XPortal.PortalInfoSubmitted(thisPortal, portalNameInputField.text, selectedTargetId, defaultPortalToggle.isOn, GetSubmittedNetworkOwnerPlayerId());
             Hide();
         }
 
@@ -350,7 +530,7 @@ namespace XPortal.UI
             if (!mainPanel)
             {
                 // Minimum width of Main Panel so that everything fits
-                float mainPanelWidthMin = padding + labelWidth + padding + inputLongWidth + padding;
+                var mainPanelWidthMin = padding + labelWidth + padding + inputLongWidth + padding;
 
                 var GuiHook = GameObject.Find("_GameMain/LoadingGUI/CustomGUIFront");
                 
@@ -367,7 +547,7 @@ namespace XPortal.UI
                         anchorMax: new Vector2(0.5f, 0.5f),
                         position: new Vector2(0f, 0f),
                         width: mainPanelWidthMin,
-                        height: 320f,
+                        height: 440f,
                         draggable: false);
                 mainPanel.name = GO_MAINPANEL;
                 mainPanel.AddComponent<CanvasGroup>();
@@ -400,13 +580,47 @@ namespace XPortal.UI
                 headerTextObject.GetComponent<RectTransform>().sizeDelta = new Vector2(250f, 50f);
 
 
+                // Portal network assignment label
+                var networkAssignLabelObject = GUIManager.Instance.CreateText(
+                        text: Localization.instance.Localize("$hud_xportal_portal_network"),
+                        parent: mainPanel.transform,
+                        anchorMin: new Vector2(0f, 1f),
+                        anchorMax: new Vector2(0f, 1f),
+                        position: new Vector2(firstColumnLeft, networkAssignRowTop),
+                        font: GUIManager.Instance.AveriaSerif,
+                        fontSize: 18,
+                        color: GUIManager.Instance.ValheimOrange,
+                        outline: true,
+                        outlineColor: Color.black,
+                        width: labelWidth,
+                        height: rowHeight,
+                        addContentSizeFitter: false);
+                networkAssignLabelObject.name = GO_NETWORKASSIGNLABEL;
+                networkAssignLabelObject.GetComponent<RectTransform>().pivot = new Vector2(0, 1);
+                networkAssignLabelObject.GetComponent<Text>().alignment = TextAnchor.MiddleLeft;
+                networkAssignLabelObject.GetComponent<Text>().horizontalOverflow = HorizontalWrapMode.Overflow;
+
+                var networkAssignDropdownObject = GUIManager.Instance.CreateDropDown(
+                        parent: mainPanel.transform,
+                        anchorMin: new Vector2(0f, 1f),
+                        anchorMax: new Vector2(1f, 1f),
+                        position: new Vector2(secondColumnLeft, networkAssignRowTop),
+                        fontSize: 18,
+                        width: inputLongWidth,
+                        height: rowHeight);
+                networkAssignDropdownObject.name = GO_NETWORKASSIGNDROPDOWN;
+                networkAssignmentDropdown = networkAssignDropdownObject.GetComponent<Dropdown>();
+                networkAssignmentDropdown.GetComponent<RectTransform>().pivot = new Vector2(0, 1);
+                ApplyDropdownStyle(networkAssignmentDropdown);
+
+
                 // Portal name label
                 var portalNameLabelObject = GUIManager.Instance.CreateText(
                         text: Localization.instance.Localize("$piece_portal_tag"), // "Name"
                         parent: mainPanel.transform,
                         anchorMin: new Vector2(0f, 1f),    // anchor top left
                         anchorMax: new Vector2(0f, 1f),
-                        position: new Vector2(firstColumnLeft, firstRowTop),
+                        position: new Vector2(firstColumnLeft, nameRowTop),
                         font: GUIManager.Instance.AveriaSerif,
                         fontSize: 18,
                         color: GUIManager.Instance.ValheimOrange,
@@ -428,7 +642,7 @@ namespace XPortal.UI
                         parent: mainPanel.transform,
                         anchorMin: new Vector2(0f, 1f),     // anchor top left
                         anchorMax: new Vector2(1f, 1f),     // anchor top right (so it stretches along with the panel)
-                        position: new Vector2(secondColumnLeft, firstRowTop),
+                        position: new Vector2(secondColumnLeft, nameRowTop),
                         contentType: InputField.ContentType.Standard,
                         placeholderText: Localization.instance.Localize("$piece_portal_tag.."), // "Name.."
                         fontSize: 18,
@@ -439,13 +653,47 @@ namespace XPortal.UI
                 portalNameInputField = portalNameInputObject.GetComponent<InputField>();
 
 
+                // Destination network label
+                var destinationNetworkLabelObject = GUIManager.Instance.CreateText(
+                    text: Localization.instance.Localize("$hud_xportal_destination_network"),
+                    parent: mainPanel.transform,
+                    anchorMin: new Vector2(0f, 1f),
+                    anchorMax: new Vector2(0f, 1f),
+                    position: new Vector2(firstColumnLeft, destinationNetworkRowTop),
+                    font: GUIManager.Instance.AveriaSerif,
+                    fontSize: 18,
+                    color: GUIManager.Instance.ValheimOrange,
+                    outline: true,
+                    outlineColor: Color.black,
+                    width: labelWidth,
+                    height: rowHeight,
+                    addContentSizeFitter: false);
+                destinationNetworkLabelObject.name = GO_DESTINATIONNETWORKLABEL;
+                destinationNetworkLabelObject.GetComponent<RectTransform>().pivot = new Vector2(0, 1);
+                destinationNetworkLabelObject.GetComponent<Text>().alignment = TextAnchor.MiddleLeft;
+                destinationNetworkLabelObject.GetComponent<Text>().horizontalOverflow = HorizontalWrapMode.Overflow;
+
+                var destinationNetworkDropdownObject = GUIManager.Instance.CreateDropDown(
+                        parent: mainPanel.transform,
+                        anchorMin: new Vector2(0f, 1f),
+                        anchorMax: new Vector2(1f, 1f),
+                        position: new Vector2(secondColumnLeft, destinationNetworkRowTop),
+                        fontSize: 18,
+                        width: inputLongWidth,
+                        height: rowHeight);
+                destinationNetworkDropdownObject.name = GO_DESTINATIONNETWORKDROPDOWN;
+                destinationNetworkDropdown = destinationNetworkDropdownObject.GetComponent<Dropdown>();
+                destinationNetworkDropdown.GetComponent<RectTransform>().pivot = new Vector2(0, 1);
+                ApplyDropdownStyle(destinationNetworkDropdown);
+
+
                 // Target portal label
                 var targetPortalLabelObject = GUIManager.Instance.CreateText(
-                    text: Localization.instance.Localize("$piece_portal_target"),
+                    text: Localization.instance.Localize("$hud_xportal_destination_portal"),
                     parent: mainPanel.transform,
                     anchorMin: new Vector2(0f, 1f),    // anchor top left
                     anchorMax: new Vector2(0f, 1f),
-                    position: new Vector2(firstColumnLeft, secondRowTop),
+                    position: new Vector2(firstColumnLeft, destinationPortalRowTop),
                     font: GUIManager.Instance.AveriaSerif,
                     fontSize: 18,
                     color: GUIManager.Instance.ValheimOrange,
@@ -467,7 +715,7 @@ namespace XPortal.UI
                         parent: mainPanel.transform,
                         anchorMin: new Vector2(0f, 1f),    // anchor top left
                         anchorMax: new Vector2(1f, 1f),    // anchor top right (so it stretches along with the panel)
-                        position: new Vector2(secondColumnLeft, secondRowTop),
+                        position: new Vector2(secondColumnLeft, destinationPortalRowTop),
                         fontSize: 18,
                         width: inputShortWidth,
                         height: rowHeight);
@@ -501,7 +749,7 @@ namespace XPortal.UI
                         parent: mainPanel.transform,
                         anchorMin: new Vector2(1f, 1f),    // anchor top right
                         anchorMax: new Vector2(1f, 1f),
-                        position: new Vector2(0 - padding - buttonWidth, secondRowTop),
+                        position: new Vector2(0 - padding - buttonWidth, destinationPortalRowTop),
                         width: buttonWidth,
                         height: rowHeight);
                 pingMapButtonObject.name = GO_PINGMAPBUTTON;
@@ -516,7 +764,7 @@ namespace XPortal.UI
                         parent: mainPanel.transform,
                         anchorMin: new Vector2(0f, 1f),    // anchor top left
                         anchorMax: new Vector2(0f, 1f),
-                        position: new Vector2(firstColumnLeft, thirdRowTop),
+                        position: new Vector2(firstColumnLeft, defaultPortalRowTop),
                         font: GUIManager.Instance.AveriaSerif,
                         fontSize: 18,
                         color: GUIManager.Instance.ValheimOrange,
@@ -545,7 +793,7 @@ namespace XPortal.UI
                 defaultPortalCheckboxRt.pivot = new Vector2(0f, 1f);        // pivot top left
                 defaultPortalCheckboxRt.anchorMin = new Vector2(0f, 1f);    // anchor top left
                 defaultPortalCheckboxRt.anchorMax = new Vector2(0f, 1f);
-                defaultPortalCheckboxRt.anchoredPosition = new Vector2(secondColumnLeft + extraPadding, thirdRowTop - extraPadding);
+                defaultPortalCheckboxRt.anchoredPosition = new Vector2(secondColumnLeft + extraPadding, defaultPortalRowTop - extraPadding);
 
                 defaultPortalToggle = defaultPortalCheckboxObject.GetComponent<Toggle>();
                 defaultPortalToggle.isOn = false;
@@ -668,6 +916,8 @@ namespace XPortal.UI
         public void Dispose()
         {
             targetPortalDropdown?.onValueChanged.RemoveAllListeners();
+            networkAssignmentDropdown?.onValueChanged.RemoveAllListeners();
+            destinationNetworkDropdown?.onValueChanged.RemoveAllListeners();
 
             if (targetPortalDropdown)
                 GameObject.Destroy(targetPortalDropdown);

--- a/XPortal/UI/PortalConfigurationPanel.cs
+++ b/XPortal/UI/PortalConfigurationPanel.cs
@@ -1,11 +1,15 @@
-﻿using Jotunn;
-using Jotunn.Configs;
-using Jotunn.Managers;
-using System;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using Jotunn;
+using Jotunn.Configs;
+using Jotunn.Managers;
+using Mod;
 using TMPro;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
 namespace XPortal.UI
@@ -18,20 +22,20 @@ namespace XPortal.UI
         public static PortalConfigurationPanel Instance { get { return lazy.Value; } }
         ////////////////////////////
 
-        internal const string GO_MAINPANEL = Mod.Info.Name + "_MainPanel";
-        internal const string GO_HEADERTEXT = Mod.Info.Name + "_PanelHeader";
-        internal const string GO_NAMELABEL = Mod.Info.Name + "_NameHeader";
-        internal const string GO_NAMEINPUT = Mod.Info.Name + "_NameInput";
-        internal const string GO_DESTINATIONLABEL = Mod.Info.Name + "_DestinationHeader";
-        internal const string GO_DESTINATIONDROPDOWN = Mod.Info.Name + "_DestinationDropdown";
-        internal const string GO_DESTINATIONGAMEPADHINT = Mod.Info.Name + "_DestinationGamepadHint";
-        internal const string GO_PINGMAPBUTTON = Mod.Info.Name + "_PingMapButton";
-        internal const string GO_DEFAULTPORTALLABEL = Mod.Info.Name + "_DefaultPortalHeader";
-        internal const string GO_DEFAULTPORTALCHECKBOX = Mod.Info.Name + "_DefaultPortalCheckbox";
+        internal const string GO_MAINPANEL = Info.Name + "_MainPanel";
+        internal const string GO_HEADERTEXT = Info.Name + "_PanelHeader";
+        internal const string GO_NAMELABEL = Info.Name + "_NameHeader";
+        internal const string GO_NAMEINPUT = Info.Name + "_NameInput";
+        internal const string GO_DESTINATIONLABEL = Info.Name + "_DestinationHeader";
+        internal const string GO_DESTINATIONDROPDOWN = Info.Name + "_DestinationDropdown";
+        internal const string GO_DESTINATIONGAMEPADHINT = Info.Name + "_DestinationGamepadHint";
+        internal const string GO_PINGMAPBUTTON = Info.Name + "_PingMapButton";
+        internal const string GO_DEFAULTPORTALLABEL = Info.Name + "_DefaultPortalHeader";
+        internal const string GO_DEFAULTPORTALCHECKBOX = Info.Name + "_DefaultPortalCheckbox";
         internal const string GO_PRIVATEPORTALLABEL = Mod.Info.Name + "_PrivatePortalHeader";
         internal const string GO_PRIVATEPORTALCHECKBOX = Mod.Info.Name + "_PrivatePortalCheckbox";
-        internal const string GO_OKAYBUTTON = Mod.Info.Name + "_OkayButton";
-        internal const string GO_CANCELBUTTON = Mod.Info.Name + "_CancelButton";
+        internal const string GO_OKAYBUTTON = Info.Name + "_OkayButton";
+        internal const string GO_CANCELBUTTON = Info.Name + "_CancelButton";
         internal const string GO_NETWORKASSIGNLABEL = Mod.Info.Name + "_NetworkAssignHeader";
         internal const string GO_NETWORKASSIGNDROPDOWN = Mod.Info.Name + "_NetworkAssignDropdown";
         internal const string GO_DESTINATIONNETWORKLABEL = Mod.Info.Name + "_DestinationNetworkHeader";
@@ -114,9 +118,468 @@ namespace XPortal.UI
 
         public bool DropdownExpanded = false;
 
+        private static ScrollRect listScrollCache;
+
+        private int lastSyncedListScroll = int.MinValue;
+
+        private float listNavNextTime;
+
+        private const float ListNavInitialDelay = 0.22f;
+
+        private const float ListNavRepeatInterval = 0.065f;
+
+        private const float ListWheelSensFloor = 520f;
+
+        private const float ListBottomSlackPx = 14f;
+
+        private const string ListBottomSpacerName = "XPortal_DropdownListBottomSpacer";
+
+        private const float ListBottomSpacerH = 64f;
+
+        private sealed class ListFocusState
+        {
+            public Dropdown Target;
+
+            public int Row;
+        }
+
+        private static FieldInfo dropdownItemsField;
+
         private PortalConfigurationPanel()
         {
             dropdownIndexToZDOIDMapping = new Dictionary<int, ZDOID>();
+        }
+
+        internal static void QueueListScroll(Dropdown dropdown)
+        {
+            if (dropdown == null)
+            {
+                return;
+            }
+
+            QueuedAction.Queue(DeferredListScroll, delay: 1, state: dropdown);
+            QueuedAction.Queue(DeferredListScroll, delay: 2, state: dropdown);
+        }
+
+        private static void DeferredListScroll(bool unused, object state)
+        {
+            ApplyListScroll(state as Dropdown);
+        }
+
+        internal static void ApplyListScroll(Dropdown dropdown, bool rebuildLayout = true)
+        {
+            if (dropdown?.options == null || dropdown.options.Count == 0)
+            {
+                return;
+            }
+
+            ScrollRect scrollRect = FindListScrollRect(dropdown);
+            if (scrollRect == null)
+            {
+                return;
+            }
+
+            scrollRect.scrollSensitivity = Mathf.Max(scrollRect.scrollSensitivity, ListWheelSensFloor);
+
+            int index = Mathf.Clamp(dropdown.value, 0, dropdown.options.Count - 1);
+            RectTransform content = scrollRect.content;
+            if (content == null || content.childCount == 0)
+            {
+                return;
+            }
+
+            if (rebuildLayout)
+            {
+                LayoutRebuilder.ForceRebuildLayoutImmediate(content);
+                Canvas.ForceUpdateCanvases();
+            }
+
+            int optionCount = dropdown.options.Count;
+            int lastItemRow = Mathf.Max(0, optionCount - 1);
+            int scrollIndex = Mathf.Clamp(index, 0, lastItemRow);
+
+            float normalized;
+            if (lastItemRow <= 0)
+            {
+                normalized = 1f;
+            }
+            else if (scrollIndex >= lastItemRow)
+            {
+                normalized = 0f;
+            }
+            else if (scrollIndex <= 0)
+            {
+                normalized = 1f;
+            }
+            else
+            {
+                normalized = 1f - scrollIndex / (float)lastItemRow;
+            }
+
+            SetScrollNorm(scrollRect, normalized);
+
+            if (scrollIndex >= content.childCount)
+            {
+                FocusListRow(dropdown, scrollIndex);
+                QueueListFocus(dropdown, scrollIndex);
+                return;
+            }
+
+            RectTransform itemRt = content.GetChild(scrollIndex) as RectTransform;
+            NudgeRowIntoView(scrollRect, content, itemRt);
+
+            FocusListRow(dropdown, scrollIndex);
+            QueueListFocus(dropdown, scrollIndex);
+        }
+
+        private static Toggle ItemToggle(Dropdown dropdown, int index)
+        {
+            if (dropdown == null || index < 0)
+            {
+                return null;
+            }
+
+            if (dropdownItemsField == null)
+            {
+                dropdownItemsField = typeof(Dropdown).GetField("m_Items", BindingFlags.Instance | BindingFlags.NonPublic);
+            }
+
+            if (dropdownItemsField == null)
+            {
+                return null;
+            }
+
+            IList items = dropdownItemsField.GetValue(dropdown) as IList;
+            if (items == null || index >= items.Count)
+            {
+                return null;
+            }
+
+            object entry = items[index];
+            if (entry == null)
+            {
+                return null;
+            }
+
+            Type entryType = entry.GetType();
+            FieldInfo toggleField = entryType.GetField("toggle", BindingFlags.Instance | BindingFlags.Public);
+            if (toggleField != null)
+            {
+                return toggleField.GetValue(entry) as Toggle;
+            }
+
+            PropertyInfo toggleProp = entryType.GetProperty("toggle", BindingFlags.Instance | BindingFlags.Public);
+            return toggleProp?.GetValue(entry, null) as Toggle;
+        }
+
+        private static void FocusListRow(Dropdown dropdown, int rowIndex)
+        {
+            if (Instance == null || !Instance.DropdownExpanded || dropdown == null)
+            {
+                return;
+            }
+
+            if (rowIndex < 0 || rowIndex >= dropdown.options.Count)
+            {
+                return;
+            }
+
+            Toggle toggle = ItemToggle(dropdown, rowIndex);
+            if (toggle == null)
+            {
+                ScrollRect sr = FindListScrollRect(dropdown);
+                RectTransform content = sr?.content;
+                if (content != null && rowIndex < content.childCount)
+                {
+                    Transform row = content.GetChild(rowIndex);
+                    toggle = row.GetComponent<Toggle>() ?? row.GetComponentInChildren<Toggle>(true);
+                }
+            }
+
+            if (toggle == null)
+            {
+                return;
+            }
+
+            EventSystem es = EventSystem.current;
+            if (es != null)
+            {
+                es.SetSelectedGameObject(toggle.gameObject);
+            }
+            else
+            {
+                toggle.Select();
+            }
+        }
+
+        private static void QueueListFocus(Dropdown dropdown, int rowIndex)
+        {
+            if (dropdown == null)
+            {
+                return;
+            }
+
+            var st = new ListFocusState { Target = dropdown, Row = rowIndex };
+            QueuedAction.Queue(DeferredListFocus, delay: 0, state: st);
+            QueuedAction.Queue(DeferredListFocus, delay: 1, state: st);
+            QueuedAction.Queue(DeferredListFocus, delay: 2, state: st);
+        }
+
+        private static void DeferredListFocus(bool unused, object state)
+        {
+            ListFocusState s = state as ListFocusState;
+            if (s == null)
+            {
+                return;
+            }
+
+            FocusListRow(s.Target, s.Row);
+        }
+
+        internal static void ClearListScroll()
+        {
+            listScrollCache = null;
+            if (Instance != null)
+            {
+                Instance.lastSyncedListScroll = int.MinValue;
+                Instance.listNavNextTime = 0f;
+            }
+        }
+
+        internal void SyncListScroll()
+        {
+            if (!DropdownExpanded || targetPortalDropdown == null)
+            {
+                return;
+            }
+
+            int v = targetPortalDropdown.value;
+            if (v == lastSyncedListScroll)
+            {
+                return;
+            }
+
+            lastSyncedListScroll = v;
+            ApplyListScroll(targetPortalDropdown, rebuildLayout: true);
+        }
+
+        private static MethodInfo scrollRectUpdateBounds;
+
+        private static void UpdateScrollBounds(ScrollRect scrollRect)
+        {
+            if (scrollRectUpdateBounds == null)
+            {
+                scrollRectUpdateBounds = typeof(ScrollRect).GetMethod("UpdateBounds", BindingFlags.Instance | BindingFlags.NonPublic);
+            }
+
+            scrollRectUpdateBounds?.Invoke(scrollRect, null);
+        }
+
+        private static void SetScrollNorm(ScrollRect scrollRect, float normalized)
+        {
+            normalized = Mathf.Clamp01(normalized);
+            scrollRect.verticalNormalizedPosition = normalized;
+            scrollRect.StopMovement();
+            scrollRect.velocity = Vector2.zero;
+
+            UpdateScrollBounds(scrollRect);
+            Canvas.ForceUpdateCanvases();
+
+            if (scrollRect.verticalScrollbar != null)
+            {
+                scrollRect.verticalScrollbar.SetValueWithoutNotify(normalized);
+            }
+        }
+
+        private static Camera CanvasCamera(Canvas canvas)
+        {
+            if (canvas == null)
+            {
+                return null;
+            }
+
+            if (canvas.renderMode == RenderMode.ScreenSpaceOverlay)
+            {
+                return null;
+            }
+
+            return canvas.worldCamera;
+        }
+
+        private static void ExtentsFromBounds(RectTransform item, Camera cam, Bounds lb, out float worldBottom, out float worldTop, out float screenMinY, out float screenMaxY)
+        {
+            Vector3 c = lb.center;
+            Vector3 e = lb.extents;
+            worldBottom = float.MaxValue;
+            worldTop = float.MinValue;
+            screenMinY = float.MaxValue;
+            screenMaxY = float.MinValue;
+
+            for (int a = 0; a < 8; a++)
+            {
+                Vector3 local = c + new Vector3(
+                    (a & 1) != 0 ? e.x : -e.x,
+                    (a & 2) != 0 ? e.y : -e.y,
+                    (a & 4) != 0 ? e.z : -e.z);
+                Vector3 w = item.TransformPoint(local);
+                worldBottom = Mathf.Min(worldBottom, w.y);
+                worldTop = Mathf.Max(worldTop, w.y);
+                float sy = RectTransformUtility.WorldToScreenPoint(cam, w).y;
+                screenMinY = Mathf.Min(screenMinY, sy);
+                screenMaxY = Mathf.Max(screenMaxY, sy);
+            }
+        }
+
+        private static float CornersMinScreenY(Vector3[] corners, Camera cam)
+        {
+            float m = float.MaxValue;
+            for (int i = 0; i < 4; i++)
+            {
+                m = Mathf.Min(m, RectTransformUtility.WorldToScreenPoint(cam, corners[i]).y);
+            }
+
+            return m;
+        }
+
+        private static float CornersMaxScreenY(Vector3[] corners, Camera cam)
+        {
+            float m = float.MinValue;
+            for (int i = 0; i < 4; i++)
+            {
+                m = Mathf.Max(m, RectTransformUtility.WorldToScreenPoint(cam, corners[i]).y);
+            }
+
+            return m;
+        }
+
+        private static void NudgeRowIntoView(ScrollRect scrollRect, RectTransform content, RectTransform item)
+        {
+            RectTransform viewport = scrollRect.viewport;
+            if (viewport == null || content == null || item == null)
+            {
+                return;
+            }
+
+            Canvas canvas = viewport.GetComponentInParent<Canvas>();
+            Camera cam = CanvasCamera(canvas);
+
+            RectTransform parentRt = content.parent as RectTransform;
+
+            const int maxSteps = 28;
+            const float epsWorld = 0.5f;
+
+            Vector3[] viewportCorners = new Vector3[4];
+
+            for (int step = 0; step < maxSteps; step++)
+            {
+                Canvas.ForceUpdateCanvases();
+
+                Bounds itemLocalBounds = RectTransformUtility.CalculateRelativeRectTransformBounds(item);
+                ExtentsFromBounds(item, cam, itemLocalBounds, out float itemBottom, out float itemTop, out float itemBottomScreen, out float itemTopScreen);
+
+                viewport.GetWorldCorners(viewportCorners);
+                float viewBottom = Mathf.Min(viewportCorners[0].y, viewportCorners[3].y);
+                float viewTop = Mathf.Max(viewportCorners[1].y, viewportCorners[2].y);
+
+                float slackWorld = 0f;
+                if (canvas != null)
+                {
+                    float viewPixelH = Mathf.Max(1f, viewport.rect.height * canvas.scaleFactor);
+                    float viewWorldH = Mathf.Abs(viewTop - viewBottom);
+                    slackWorld = ListBottomSlackPx / viewPixelH * Mathf.Max(viewWorldH, 0.0001f);
+                }
+
+                float viewBottomScreen = CornersMinScreenY(viewportCorners, cam);
+                float viewTopScreen = CornersMaxScreenY(viewportCorners, cam);
+
+                bool fitsBottom = itemBottomScreen >= viewBottomScreen - ListBottomSlackPx - 0.5f;
+                bool fitsTop = itemTopScreen <= viewTopScreen + 0.5f;
+
+                if (itemBottom >= viewBottom - epsWorld - slackWorld && itemTop <= viewTop + epsWorld && fitsBottom && fitsTop)
+                {
+                    scrollRect.StopMovement();
+                    scrollRect.velocity = Vector2.zero;
+                    return;
+                }
+
+                float shiftWorldY = 0f;
+                if (itemBottom < viewBottom - epsWorld - slackWorld || !fitsBottom)
+                {
+                    shiftWorldY = viewBottom - itemBottom - slackWorld;
+                }
+                else if (itemTop > viewTop + epsWorld || !fitsTop)
+                {
+                    shiftWorldY = viewTop - itemTop;
+                }
+
+                if (Mathf.Abs(shiftWorldY) < 0.005f)
+                {
+                    break;
+                }
+
+                if (parentRt != null)
+                {
+                    Vector2 local = parentRt.InverseTransformVector(new Vector3(0f, shiftWorldY, 0f));
+                    content.anchoredPosition += new Vector2(0f, local.y);
+                }
+                else
+                {
+                    Vector3 ls = content.InverseTransformVector(new Vector3(0f, shiftWorldY, 0f));
+                    content.anchoredPosition += new Vector2(0f, ls.y);
+                }
+
+                scrollRect.StopMovement();
+                scrollRect.velocity = Vector2.zero;
+
+                UpdateScrollBounds(scrollRect);
+            }
+
+            Canvas.ForceUpdateCanvases();
+        }
+
+        private static ScrollRect FindListScrollRect(Dropdown dropdown)
+        {
+            if (listScrollCache != null && listScrollCache)
+            {
+                return listScrollCache;
+            }
+
+            Transform root = dropdown.transform.root;
+            foreach (Transform t in root.GetComponentsInChildren<Transform>(true))
+            {
+                if (!t.gameObject.activeInHierarchy)
+                {
+                    continue;
+                }
+
+                if (t.name.IndexOf("Dropdown List", StringComparison.Ordinal) < 0)
+                {
+                    continue;
+                }
+
+                ScrollRect sr = t.GetComponent<ScrollRect>() ?? t.GetComponentInChildren<ScrollRect>(true);
+                if (sr != null && sr.content != null)
+                {
+                    listScrollCache = sr;
+                    return sr;
+                }
+            }
+
+            FieldInfo field = typeof(Dropdown).GetField("m_Dropdown", BindingFlags.Instance | BindingFlags.NonPublic);
+            object raw = field?.GetValue(dropdown);
+            GameObject go = raw as GameObject ?? (raw as Component)?.gameObject;
+            if (go == null || !go.activeInHierarchy)
+            {
+                return null;
+            }
+
+            ScrollRect found = go.GetComponent<ScrollRect>() ?? go.GetComponentInChildren<ScrollRect>(true);
+            if (found != null)
+            {
+                listScrollCache = found;
+            }
+
+            return found;
         }
 
         #region Input
@@ -139,7 +602,7 @@ namespace XPortal.UI
                 RepeatDelay = 1000f,
                 BlockOtherInputs = true,
             };
-            InputManager.Instance.AddButton(Mod.Info.GUID, newButtonConfig);
+            InputManager.Instance.AddButton(Info.GUID, newButtonConfig);
             return newButtonConfig;
         }
 
@@ -150,16 +613,50 @@ namespace XPortal.UI
                 targetPortalDropdownUpDownKeyhint.SetActive(ZInput.IsGamepadActive());
             }
 
-            if (ZInput.GetButtonUp(uiDropdownScrollUpButton.Name))
+            ProcessListNav();
+        }
+
+        private void ProcessListNav()
+        {
+            if (!DropdownExpanded || targetPortalDropdown == null)
             {
-                ScrollDropdownItem(up: true);
+                listNavNextTime = 0f;
                 return;
             }
 
-            if (ZInput.GetButtonUp(uiDropdownScrollDownButton.Name))
+            bool up = ZInput.GetButton(uiDropdownScrollUpButton.Name);
+            bool down = ZInput.GetButton(uiDropdownScrollDownButton.Name);
+
+            if (ZInput.IsGamepadActive())
             {
-                ScrollDropdownItem(up: false);
+                up = up || ZInput.GetButton("JoyLStickUp") || ZInput.GetButton("JoyDPadUp");
+                down = down || ZInput.GetButton("JoyLStickDown") || ZInput.GetButton("JoyDPadDown");
+            }
+
+            if (up && down)
+            {
+                listNavNextTime = 0f;
                 return;
+            }
+
+            if (!up && !down)
+            {
+                listNavNextTime = 0f;
+                return;
+            }
+
+            float now = Time.unscaledTime;
+            if (listNavNextTime <= 0f)
+            {
+                BumpDropdown(up);
+                listNavNextTime = now + ListNavInitialDelay;
+                return;
+            }
+
+            if (now >= listNavNextTime)
+            {
+                BumpDropdown(up);
+                listNavNextTime = now + ListNavRepeatInterval;
             }
         }
         #endregion
@@ -212,24 +709,21 @@ namespace XPortal.UI
             SetActive(false);
         }
 
-        private void ScrollDropdownItem(bool up)
+        private void BumpDropdown(bool up)
         {
-            var dropdownWasExpanded = DropdownExpanded;
-
-            if (DropdownExpanded)
+            int max = targetPortalDropdown.options.Count - 1;
+            if (max < 0)
             {
-                targetPortalDropdown.enabled = false;
-                DropdownExpanded = false;
+                return;
             }
 
-            targetPortalDropdown.value += (up ? -1 : 1);
-
-            if (dropdownWasExpanded)
+            int newVal = Mathf.Clamp(targetPortalDropdown.value + (up ? -1 : 1), 0, max);
+            if (newVal == targetPortalDropdown.value)
             {
-                targetPortalDropdown.enabled = true;
-                targetPortalDropdown.Show();
-                DropdownExpanded = true;
+                return;
             }
+
+            targetPortalDropdown.value = newVal;
         }
 
         private void SetPingMapButtonActive(bool active)
@@ -464,7 +958,6 @@ namespace XPortal.UI
 
             if (privatePortalToggle.isOn && !defaultPortalToggle.isOn)
             {
-                return personalId;
             }
 
             if (!networkAssignmentIndexToOwnerId.TryGetValue(networkAssignmentDropdown.value, out var ownerId))
@@ -1072,6 +1565,27 @@ namespace XPortal.UI
             // Make the expanded list larger
             dropdown.template.GetComponent<RectTransform>().sizeDelta = new Vector2(0f, 400f);
 
+            Transform contentTransform = dropdown.template.Find("Viewport/Content");
+            if (contentTransform != null)
+            {
+                VerticalLayoutGroup contentVlg = contentTransform.GetComponent<VerticalLayoutGroup>();
+                if (contentVlg != null)
+                {
+                    contentVlg.padding.bottom = Mathf.Max(contentVlg.padding.bottom, 20);
+                }
+
+                if (contentTransform.Find(ListBottomSpacerName) == null)
+                {
+                    GameObject spacerGo = new GameObject(ListBottomSpacerName, typeof(RectTransform), typeof(LayoutElement));
+                    spacerGo.transform.SetParent(contentTransform, false);
+                    LayoutElement spacerLe = spacerGo.GetComponent<LayoutElement>();
+                    spacerLe.minHeight = ListBottomSpacerH;
+                    spacerLe.preferredHeight = ListBottomSpacerH;
+                    spacerLe.flexibleHeight = 0f;
+                    spacerGo.transform.SetAsLastSibling();
+                }
+            }
+
             // Get the template item
             var templateItem = dropdown.template.Find("Viewport/Content/Item");
 
@@ -1119,6 +1633,9 @@ namespace XPortal.UI
             var goGamepadHint = new GameObject("gamepad_hint", typeof(RectTransform), typeof(TextMeshProUGUI));
 
             var textMesh = goGamepadHint.GetComponent<TextMeshProUGUI>();
+            var font = Resources.FindObjectsOfTypeAll<TMP_FontAsset>().FirstOrDefault(fa => fa.name == "Valheim-AveriaSansLibre");
+
+            textMesh.font = !font ? TMP_Settings.defaultFontAsset : font;
             textMesh.text = $"$KEY_{buttonName}";
             textMesh.fontSize = 18;
             textMesh.alignment = TextAlignmentOptions.Center;

--- a/XPortal/XPortal.cs
+++ b/XPortal/XPortal.cs
@@ -77,6 +77,7 @@ namespace XPortal
             }
 
             PortalConfigurationPanel.Instance.HandleInput();
+            PortalConfigurationPanel.Instance.SyncListScroll();
         }
 
         /// <summary>

--- a/XPortal/XPortal.cs
+++ b/XPortal/XPortal.cs
@@ -18,6 +18,8 @@ namespace XPortal
     {
         public const string Key_TargetId = Mod.Info.Name + "_TargetId";
         public const string Key_PreviousId = Mod.Info.Name + "_PreviousId";
+        public const string Key_NetworkOwnerPlayerId = Mod.Info.Name + "_NetworkOwnerPlayerId";
+        public const string Key_NetworkOwnerDisplayName = Mod.Info.Name + "_NetworkOwnerDisplayName";
 
         public const string StonePortalPrefabName = "portal";
 
@@ -121,7 +123,7 @@ namespace XPortal
                 return;
             }
 
-            ItemDrop hammer = ObjectDB.instance.GetItemPrefab("Hammer")?.GetComponent<ItemDrop>();
+            var hammer = ObjectDB.instance.GetItemPrefab("Hammer")?.GetComponent<ItemDrop>();
             if (!hammer)
             {
                 Log.Error("Could not find Hammer prefab");
@@ -190,12 +192,12 @@ namespace XPortal
 
         #region Patch Events
         /// <summary>
-        /// Called by a patch on Game.Start.
-        /// At this point the world is beginning to load. The portals don't exist yet.
+        /// Called from a Game.Start patch. Resets portal and admin-sync state, then registers RPC handlers.
         /// </summary>
         internal static void GameStarted()
         {
             KnownPortalsManager.Instance.Reset();
+            XPortalAdminSync.ResetForNewSession();
             RPCManager.Register();
         }
 
@@ -254,9 +256,9 @@ namespace XPortal
         /// <summary>
         /// When interacting with a portal, we want to show the XPortal UI
         /// </summary>
-        /// <param name="portalId"></param>
-        internal static void OnPortalRequestText(ZDOID portalId)
+        internal static void OnPortalRequestText(TeleportWorld teleportWorld)
         {
+            var portalId = teleportWorld.m_nview.GetZDO().m_uid;
             if (!KnownPortalsManager.Instance.ContainsId(portalId))
             {
                 // TODO: show a friendly message on the screen
@@ -266,7 +268,10 @@ namespace XPortal
 
             var portal = KnownPortalsManager.Instance.GetKnownPortalById(portalId);
             Log.Debug($"Interacting with: {portal}");
-            PortalConfigurationPanel.Instance.ConfigurePortal(portal);
+            var piece = teleportWorld.GetComponent<Piece>();
+            var mayEditNetworkAsAdmin = XPortalAdminSync.IsLocalPortalNetworkAdmin();
+            var canEditNetwork = piece != null && (piece.IsCreator() || mayEditNetworkAsAdmin);
+            PortalConfigurationPanel.Instance.ConfigurePortal(portal, canEditNetwork);
         }
 
         /// <summary>
@@ -352,7 +357,7 @@ namespace XPortal
         /// <param name="portal">The KnownPortal that was being configured</param>
         /// <param name="newName">The new name for the portal</param>
         /// <param name="newTarget">The new target for the portal</param>
-        internal static void PortalInfoSubmitted(KnownPortal portal, string newName, ZDOID newTarget, bool defaultPortal)
+        internal static void PortalInfoSubmitted(KnownPortal portal, string newName, ZDOID newTarget, bool defaultPortal, long networkOwnerPlayerId)
         {
             if (defaultPortal)
             {
@@ -369,10 +374,35 @@ namespace XPortal
                 }
             }
 
-            if (!portal.Name.Equals(newName) || !portal.Targets(newTarget))
+            var localPlayerId = Player.m_localPlayer != null
+                ? Player.m_localPlayer.GetPlayerID()
+                : Game.instance.GetPlayerProfile().GetPlayerID();
+            var portalZdo = ZDOMan.instance != null ? ZDOMan.instance.GetZDO(portal.Id) : null;
+            var pieceCreator = portalZdo != null ? portalZdo.GetLong(ZDOVars.s_creator) : 0L;
+
+            var networkOwnerDisplayName = portal.NetworkOwnerDisplayName ?? string.Empty;
+            if (networkOwnerPlayerId == 0L)
+            {
+                networkOwnerDisplayName = string.Empty;
+            }
+            else if (pieceCreator != 0L && localPlayerId == pieceCreator)
+            {
+                var fromPlayer = Player.m_localPlayer != null
+                    ? Player.m_localPlayer.GetPlayerName()
+                    : Game.instance.GetPlayerProfile().GetName();
+                networkOwnerDisplayName = PortalNetwork.SanitizeNetworkOwnerDisplayName(fromPlayer);
+            }
+
+            var networkChanged = portal.NetworkOwnerPlayerId != networkOwnerPlayerId;
+            var nameOrTargetChanged = !portal.Name.Equals(newName) || !portal.Targets(newTarget);
+            var networkDisplayNameChanged = !string.Equals(portal.NetworkOwnerDisplayName ?? string.Empty, networkOwnerDisplayName, System.StringComparison.Ordinal);
+
+            if (nameOrTargetChanged || networkChanged || networkDisplayNameChanged)
             {
                 portal.Name = newName;
                 portal.Target = newTarget;
+                portal.NetworkOwnerPlayerId = networkOwnerPlayerId;
+                portal.NetworkOwnerDisplayName = networkOwnerDisplayName;
 
                 // Ask the server to update the portal
                 Log.Debug($"Updating portal `{portal.Name}`");
@@ -396,8 +426,8 @@ namespace XPortal
             Log.Debug($"Pinging portal: {portal}");
 
             // Get selected portal name and position
-            string name = portal.GetFriendlyName();
-            Vector3 location = portal.Location;
+            var name = portal.GetFriendlyName();
+            var location = portal.Location;
 
             // Send ping to all players
             SendToClient.PingMap(location, name);

--- a/XPortal/XPortal.cs
+++ b/XPortal/XPortal.cs
@@ -316,13 +316,18 @@ namespace XPortal
         /// <param name="portalId">The ZDOID of the portal being destroyed</param>
         internal static void OnPortalDestroyed(ZDOID portalId)
         {
-            if (!KnownPortalsManager.Instance.ContainsId(portalId))
+            if (KnownPortalsManager.Instance.ContainsId(portalId))
             {
-                Log.Error($"Portal `{portalId}` is being destroyed, but XPortal does not know it");
-                return;
+                var portalName = KnownPortalsManager.Instance.GetKnownPortalById(portalId).Name;
+                Log.Debug($"Portal `{portalName}` is being destroyed");
+                KnownPortalsManager.Instance.Remove(portalId);
             }
-            var portalName = KnownPortalsManager.Instance.GetKnownPortalById(portalId).Name;
-            Log.Debug($"Portal `{portalName}` is being destroyed");
+            else
+            {
+                // Normal if placement never registered (sync/order) or list was cleared; server may still track it.
+                Log.Debug($"Portal `{portalId}` destroyed — was not in local known list; notifying server anyway");
+            }
+
             SendToServer.RemoveRequest(portalId);
         }
 

--- a/XPortal/XPortal.cs
+++ b/XPortal/XPortal.cs
@@ -20,6 +20,7 @@ namespace XPortal
         public const string Key_PreviousId = Mod.Info.Name + "_PreviousId";
         public const string Key_NetworkOwnerPlayerId = Mod.Info.Name + "_NetworkOwnerPlayerId";
         public const string Key_NetworkOwnerDisplayName = Mod.Info.Name + "_NetworkOwnerDisplayName";
+        public const string Key_IsPrivate = Mod.Info.Name + "_IsPrivate";
 
         public const string StonePortalPrefabName = "portal";
 
@@ -270,8 +271,10 @@ namespace XPortal
             Log.Debug($"Interacting with: {portal}");
             var piece = teleportWorld.GetComponent<Piece>();
             var mayEditNetworkAsAdmin = XPortalAdminSync.IsLocalPortalNetworkAdmin();
-            var canEditNetwork = piece != null && (piece.IsCreator() || mayEditNetworkAsAdmin);
-            PortalConfigurationPanel.Instance.ConfigurePortal(portal, canEditNetwork);
+            var isCreator = piece != null && piece.IsCreator();
+            var canEditNetwork = isCreator || mayEditNetworkAsAdmin;
+            var canEditPortalFully = isCreator || mayEditNetworkAsAdmin;
+            PortalConfigurationPanel.Instance.ConfigurePortal(portal, canEditNetwork, canEditPortalFully);
         }
 
         /// <summary>
@@ -303,6 +306,46 @@ namespace XPortal
             var portalName = KnownPortalsManager.Instance.GetKnownPortalById(portalId).Name;
             Log.Debug($"Portal `{portalName}` is being destroyed");
             SendToServer.RemoveRequest(portalId);
+        }
+
+        /// <summary>
+        /// True when playerId may not use this portal because the destination is someone else’s private portal.
+        /// </summary>
+        internal static bool PrivateUseBlocked(ZDOID sourcePortalId, long playerId)
+        {
+            if (!KnownPortalsManager.Instance.TryGetValue(sourcePortalId, out var source)
+                || !source.HasTarget()
+                || !KnownPortalsManager.Instance.TryGetValue(source.Target, out var dest)
+                || !dest.IsPrivate)
+            {
+                return false;
+            }
+
+            var destZdo = ZDOMan.instance != null ? ZDOMan.instance.GetZDO(dest.Id) : null;
+            var creator = destZdo != null ? destZdo.GetLong(ZDOVars.s_creator) : 0L;
+            return creator != playerId;
+        }
+
+        internal static bool LocalPrivateUseBlocked(ZDOID sourcePortalId)
+        {
+            return Player.m_localPlayer != null && PrivateUseBlocked(sourcePortalId, Player.m_localPlayer.GetPlayerID());
+        }
+
+        /// <summary>For <c>TeleportWorld.UpdatePortal</c> transpiler: same as <see cref="PrivateUseBlocked"/> but takes live instances.</summary>
+        internal static bool IsUsablePortal(TeleportWorld portal, Player player, bool originalFlag)
+        {
+            if (!originalFlag || portal == null || player == null || portal.m_nview == null || !portal.m_nview.IsValid())
+                return false;
+
+            var zdo = portal.m_nview.GetZDO();
+            if (zdo == null)
+            {
+                return true;
+            }
+            
+            var useBlocked = PrivateUseBlocked(zdo.m_uid, player.GetPlayerID());
+
+            return !useBlocked;
         }
         #endregion
 
@@ -357,7 +400,7 @@ namespace XPortal
         /// <param name="portal">The KnownPortal that was being configured</param>
         /// <param name="newName">The new name for the portal</param>
         /// <param name="newTarget">The new target for the portal</param>
-        internal static void PortalInfoSubmitted(KnownPortal portal, string newName, ZDOID newTarget, bool defaultPortal, long networkOwnerPlayerId)
+        internal static void PortalInfoSubmitted(KnownPortal portal, string newName, ZDOID newTarget, bool defaultPortal, long networkOwnerPlayerId, bool isPrivate)
         {
             if (defaultPortal)
             {
@@ -380,8 +423,14 @@ namespace XPortal
             var portalZdo = ZDOMan.instance != null ? ZDOMan.instance.GetZDO(portal.Id) : null;
             var pieceCreator = portalZdo != null ? portalZdo.GetLong(ZDOVars.s_creator) : 0L;
 
+            var effectiveNetworkId = networkOwnerPlayerId;
+            if (isPrivate)
+            {
+                effectiveNetworkId = pieceCreator != 0L ? pieceCreator : localPlayerId;
+            }
+
             var networkOwnerDisplayName = portal.NetworkOwnerDisplayName ?? string.Empty;
-            if (networkOwnerPlayerId == 0L)
+            if (effectiveNetworkId == 0L)
             {
                 networkOwnerDisplayName = string.Empty;
             }
@@ -393,16 +442,18 @@ namespace XPortal
                 networkOwnerDisplayName = PortalNetwork.SanitizeNetworkOwnerDisplayName(fromPlayer);
             }
 
-            var networkChanged = portal.NetworkOwnerPlayerId != networkOwnerPlayerId;
+            var networkChanged = portal.NetworkOwnerPlayerId != effectiveNetworkId;
             var nameOrTargetChanged = !portal.Name.Equals(newName) || !portal.Targets(newTarget);
             var networkDisplayNameChanged = !string.Equals(portal.NetworkOwnerDisplayName ?? string.Empty, networkOwnerDisplayName, System.StringComparison.Ordinal);
+            var privateChanged = portal.IsPrivate != isPrivate;
 
-            if (nameOrTargetChanged || networkChanged || networkDisplayNameChanged)
+            if (nameOrTargetChanged || networkChanged || networkDisplayNameChanged || privateChanged)
             {
                 portal.Name = newName;
                 portal.Target = newTarget;
-                portal.NetworkOwnerPlayerId = networkOwnerPlayerId;
+                portal.NetworkOwnerPlayerId = effectiveNetworkId;
                 portal.NetworkOwnerDisplayName = networkOwnerDisplayName;
+                portal.IsPrivate = isPrivate;
 
                 // Ask the server to update the portal
                 Log.Debug($"Updating portal `{portal.Name}`");

--- a/XPortal/XPortal.cs
+++ b/XPortal/XPortal.cs
@@ -404,6 +404,7 @@ namespace XPortal
         {
             if (defaultPortal)
             {
+                isPrivate = false;
                 // The "Default Portal" checkbox is checked: make this the default portal
                 XPortalConfig.Instance.Local.DefaultPortal.Value = portal.Location.Round();
             }

--- a/XPortal/XPortal.cs
+++ b/XPortal/XPortal.cs
@@ -310,6 +310,8 @@ namespace XPortal
 
         /// <summary>
         /// True when playerId may not use this portal because the destination is someone else’s private portal.
+        /// Uses piece creator when present; falls back to <see cref="KnownPortal.NetworkOwnerPlayerId"/> so clients
+        /// still allow the owner when <see cref="ZDOVars.s_creator"/> is not replicated yet (0).
         /// </summary>
         internal static bool PrivateUseBlocked(ZDOID sourcePortalId, long playerId)
         {
@@ -323,7 +325,9 @@ namespace XPortal
 
             var destZdo = ZDOMan.instance != null ? ZDOMan.instance.GetZDO(dest.Id) : null;
             var creator = destZdo != null ? destZdo.GetLong(ZDOVars.s_creator) : 0L;
-            return creator != playerId;
+            var isOwnerByCreator = creator != 0L && creator == playerId;
+            var isOwnerByNetwork = dest.NetworkOwnerPlayerId != 0L && dest.NetworkOwnerPlayerId == playerId;
+            return !isOwnerByCreator && !isOwnerByNetwork;
         }
 
         internal static bool LocalPrivateUseBlocked(ZDOID sourcePortalId)

--- a/XPortal/XPortal.cs
+++ b/XPortal/XPortal.cs
@@ -44,6 +44,8 @@ namespace XPortal
             XPortalConfig.Instance.OnLocalConfigChanged += OnLocalConfigChanged;
             XPortalConfig.Instance.OnServerConfigChanged += OnServerConfigChanged;
 
+            CustomNetworks.ListChanged += OnNetworksListChanged;
+
             if (!Environment.IsHeadless)
             {
                 // Add buttons
@@ -87,6 +89,7 @@ namespace XPortal
             KnownPortalsManager.Instance.ReportAllPortals();
 
             Patches.Patcher.Unpatch();
+            CustomNetworks.ShutdownServer();
             if (!Environment.IsHeadless)
             {
                 PortalConfigurationPanel.Instance?.Dispose();
@@ -104,6 +107,7 @@ namespace XPortal
         {
             // Ask the server to send us the config
             SendToServer.ConfigRequest();
+            SendToServer.RequestCustomNetworks();
 
             // Ask the server to send us the portals
             var myId = ZDOMan.GetSessionID();
@@ -180,6 +184,14 @@ namespace XPortal
         #endregion
 
         #region Config events
+        private static void OnNetworksListChanged()
+        {
+            if (!Environment.IsHeadless)
+            {
+                PortalConfigurationPanel.Instance.OnNetworksListChanged();
+            }
+        }
+
         internal static void OnLocalConfigChanged()
         {
             // Honestly, nobody cares
@@ -192,14 +204,17 @@ namespace XPortal
         #endregion
 
         #region Patch Events
-        /// <summary>
-        /// Called from a Game.Start patch. Resets portal and admin-sync state, then registers RPC handlers.
-        /// </summary>
+        /// <summary>Game start: reset state and register RPCs.</summary>
         internal static void GameStarted()
         {
             KnownPortalsManager.Instance.Reset();
             XPortalAdminSync.ResetForNewSession();
+            CustomNetworks.ResetSession();
             RPCManager.Register();
+            if (Environment.IsServer)
+            {
+                CustomNetworks.InitializeServer();
+            }
         }
 
         /// <summary>
@@ -289,6 +304,8 @@ namespace XPortal
             ZDOMan.instance.ForceSendZDO(portalId);
 
             var portal = new KnownPortal(portalId, location);
+            KnownPortalsManager.Instance.AddOrUpdate(portal);
+            ZdoTools.UpdateFromKnownPortal(state: portal);
             SendToServer.AddOrUpdateRequest(portal);
         }
 
@@ -308,11 +325,7 @@ namespace XPortal
             SendToServer.RemoveRequest(portalId);
         }
 
-        /// <summary>
-        /// True when playerId may not use this portal because the destination is someone else’s private portal.
-        /// Uses piece creator when present; falls back to <see cref="KnownPortal.NetworkOwnerPlayerId"/> so clients
-        /// still allow the owner when <see cref="ZDOVars.s_creator"/> is not replicated yet (0).
-        /// </summary>
+        /// <summary>True if the target is another player’s private portal and this player is not allowed to use it.</summary>
         internal static bool PrivateUseBlocked(ZDOID sourcePortalId, long playerId)
         {
             if (!KnownPortalsManager.Instance.TryGetValue(sourcePortalId, out var source)
@@ -335,7 +348,7 @@ namespace XPortal
             return Player.m_localPlayer != null && PrivateUseBlocked(sourcePortalId, Player.m_localPlayer.GetPlayerID());
         }
 
-        /// <summary>For <c>TeleportWorld.UpdatePortal</c> transpiler: same as <see cref="PrivateUseBlocked"/> but takes live instances.</summary>
+        /// <summary>Like PrivateUseBlocked but used from TeleportWorld with live portal/player instances.</summary>
         internal static bool IsUsablePortal(TeleportWorld portal, Player player, bool originalFlag)
         {
             if (!originalFlag || portal == null || player == null || portal.m_nview == null || !portal.m_nview.IsValid())
@@ -365,6 +378,11 @@ namespace XPortal
             Log.Debug($"Fetched {allPortalZDOs.Count} portals");
 
             ForceLocalPortalUpdate(allPortalZDOs);
+
+            if (Environment.IsServer)
+            {
+                CustomNetworks.MigrateInvalidNetworks();
+            }
 
             SendToClient.Resync(KnownPortalsManager.Instance.Pack(), reason);
 
@@ -438,6 +456,12 @@ namespace XPortal
             if (effectiveNetworkId == 0L)
             {
                 networkOwnerDisplayName = string.Empty;
+            }
+            else if (CustomNetworks.IsReservedIdRange(effectiveNetworkId))
+            {
+                networkOwnerDisplayName = CustomNetworks.TryGetDisplayName(effectiveNetworkId, out var customLabel)
+                    ? customLabel
+                    : string.Empty;
             }
             else if (pieceCreator != 0L && localPlayerId == pieceCreator)
             {

--- a/XPortal/XPortal.csproj
+++ b/XPortal/XPortal.csproj
@@ -83,6 +83,7 @@
   <ItemGroup>
     <Compile Include="Environment.cs" />
     <Compile Include="Extension\Vector3.cs" />
+    <Compile Include="CustomNetworks.cs" />
     <Compile Include="KnownPortalsManager.cs" />
     <Compile Include="Log.cs" />
     <Compile Include="ModInfo.cs" />
@@ -120,6 +121,7 @@
     <Compile Include="ZdoTools.cs" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="xportal_networks.json" />
     <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="Translations\Chinese\xportal-translation-chinese.json" />

--- a/XPortal/XPortal.csproj
+++ b/XPortal/XPortal.csproj
@@ -86,6 +86,10 @@
     <Compile Include="KnownPortalsManager.cs" />
     <Compile Include="Log.cs" />
     <Compile Include="ModInfo.cs" />
+    <Compile Include="NetPeerUtility.cs" />
+    <Compile Include="Patches\ZNet.cs" />
+    <Compile Include="RPC\XPortalAdminSync.cs" />
+    <Compile Include="PortalNetwork.cs" />
     <Compile Include="Patches\Dropdown.cs" />
     <Compile Include="Patches\Game.cs" />
     <Compile Include="Patches\Piece.cs" />

--- a/XPortal/XPortalConfig.cs
+++ b/XPortal/XPortalConfig.cs
@@ -1,5 +1,6 @@
 ﻿using BepInEx.Configuration;
 using System;
+using System.IO;
 using UnityEngine;
 using XPortal.RPC;
 
@@ -31,6 +32,8 @@ namespace XPortal
             public ConfigEntry<Vector3> DefaultPortal;
             public ConfigEntry<bool> DefaultPrivatePortal;
             public bool HidePortalDistance;
+            /// <summary>Server-enforced portal hammer removal rules.</summary>
+            public bool RestrictPortalRemoval;
         }
 
         /// <summary>
@@ -95,6 +98,13 @@ namespace XPortal
 
             var cfgHidePortalDistance = configFile.Bind("General", "HidePortalDistance", false, "In the list of portals, do not show how far away other portals are." + Desc_EnforcedByServer);
             Local.HidePortalDistance = cfgHidePortalDistance.Value;
+
+            var cfgRestrictPortalRemoval = configFile.Bind(
+                "General",
+                "RestrictPortalRemoval",
+                false,
+                "When true, only the player who placed the portal or a server admin may remove it with the hammer. Other removal (e.g. structural damage) is unchanged." + Desc_EnforcedByServer);
+            Local.RestrictPortalRemoval = cfgRestrictPortalRemoval.Value;
         }
 
         /// <summary>
@@ -124,6 +134,7 @@ namespace XPortal
             pkg.Write(Local.PingMapDisabled);
             pkg.Write(Local.DoublePortalCosts);
             pkg.Write(Local.HidePortalDistance);
+            pkg.Write(Local.RestrictPortalRemoval);
             return pkg;
         }
 
@@ -136,10 +147,19 @@ namespace XPortal
             Server.PingMapDisabled = pkg.ReadBool();
             Server.DoublePortalCosts = pkg.ReadBool();
             Server.HidePortalDistance = pkg.ReadBool();
+            try
+            {
+                Server.RestrictPortalRemoval = pkg.ReadBool();
+            }
+            catch (EndOfStreamException)
+            {
+                Server.RestrictPortalRemoval = false;
+            }
 
             Log.Debug($"PingMapDisabled {{ Local: {Local.PingMapDisabled}, Server: {Server.PingMapDisabled} }}");
             Log.Debug($"DoublePortalCosts {{ Local: {Local.DoublePortalCosts}, Server: {Server.DoublePortalCosts} }}");
             Log.Debug($"HidePortalDistance {{ Local: {Local.HidePortalDistance}, Server: {Server.HidePortalDistance} }}");
+            Log.Debug($"RestrictPortalRemoval {{ Local: {Local.RestrictPortalRemoval}, Server: {Server.RestrictPortalRemoval} }}");
 
             OnServerConfigChanged?.Invoke();
         }

--- a/XPortal/XPortalConfig.cs
+++ b/XPortal/XPortalConfig.cs
@@ -29,6 +29,7 @@ namespace XPortal
             public bool DisplayPortalColour;
             public bool DoublePortalCosts;
             public ConfigEntry<Vector3> DefaultPortal;
+            public ConfigEntry<bool> DefaultPrivatePortal;
             public bool HidePortalDistance;
         }
 
@@ -85,6 +86,12 @@ namespace XPortal
             Local.DoublePortalCosts = cfgDoublePortalCosts.Value;
 
             Local.DefaultPortal = configFile.Bind("General", "DefaultPortal", Vector3.zero, "The Portal that newly built Portals immediately connect to.");
+
+            Local.DefaultPrivatePortal = configFile.Bind(
+                "General",
+                "DefaultPrivatePortal",
+                true,
+                "If true, newly placed portals start as private (owner-only). If false, they start public on the Global network until changed.");
 
             var cfgHidePortalDistance = configFile.Bind("General", "HidePortalDistance", false, "In the list of portals, do not show how far away other portals are." + Desc_EnforcedByServer);
             Local.HidePortalDistance = cfgHidePortalDistance.Value;

--- a/XPortal/ZdoTools.cs
+++ b/XPortal/ZdoTools.cs
@@ -28,6 +28,26 @@
             portalZdo.SetConnection(ZDOExtraData.ConnectionType.Portal, targetId);
         }
 
+        public static long GetNetworkOwnerPlayerId(ZDO portalZdo)
+        {
+            return portalZdo.GetLong(XPortal.Key_NetworkOwnerPlayerId);
+        }
+
+        public static void SetNetworkOwnerPlayerId(ZDO portalZdo, long ownerPlayerId)
+        {
+            portalZdo.Set(XPortal.Key_NetworkOwnerPlayerId, ownerPlayerId);
+        }
+
+        public static string GetNetworkOwnerDisplayName(ZDO portalZdo)
+        {
+            return portalZdo.GetString(XPortal.Key_NetworkOwnerDisplayName);
+        }
+
+        public static void SetNetworkOwnerDisplayName(ZDO portalZdo, string displayName)
+        {
+            portalZdo.Set(XPortal.Key_NetworkOwnerDisplayName, displayName ?? string.Empty);
+        }
+
         public static void UpdateFromKnownPortal(bool delayed = false, object state = null)
         {
             if (delayed)
@@ -36,8 +56,8 @@
                 return;
             }
 
-            KnownPortal portal = (KnownPortal)state;
-            ZDO portalZdo = ZDOMan.instance.GetZDO(portal.Id);
+            var portal = (KnownPortal)state;
+            var portalZdo = ZDOMan.instance.GetZDO(portal.Id);
 
             if (portalZdo == null)
             {
@@ -49,6 +69,8 @@
             SetOwner(portalZdo);
             SetName(portalZdo, portal.Name);
             SetPreviousId(portalZdo);
+            SetNetworkOwnerPlayerId(portalZdo, portal.NetworkOwnerPlayerId);
+            SetNetworkOwnerDisplayName(portalZdo, portal.NetworkOwnerDisplayName ?? string.Empty);
             SetTarget(portalZdo, portal.Target);
         }
     }

--- a/XPortal/ZdoTools.cs
+++ b/XPortal/ZdoTools.cs
@@ -48,6 +48,16 @@
             portalZdo.Set(XPortal.Key_NetworkOwnerDisplayName, displayName ?? string.Empty);
         }
 
+        public static bool GetIsPrivate(ZDO portalZdo)
+        {
+            return portalZdo.GetBool(XPortal.Key_IsPrivate, false);
+        }
+
+        public static void SetIsPrivate(ZDO portalZdo, bool isPrivate)
+        {
+            portalZdo.Set(XPortal.Key_IsPrivate, isPrivate);
+        }
+
         public static void UpdateFromKnownPortal(bool delayed = false, object state = null)
         {
             if (delayed)
@@ -71,6 +81,7 @@
             SetPreviousId(portalZdo);
             SetNetworkOwnerPlayerId(portalZdo, portal.NetworkOwnerPlayerId);
             SetNetworkOwnerDisplayName(portalZdo, portal.NetworkOwnerDisplayName ?? string.Empty);
+            SetIsPrivate(portalZdo, portal.IsPrivate);
             SetTarget(portalZdo, portal.Target);
         }
     }

--- a/XPortal/xportal_networks.json
+++ b/XPortal/xportal_networks.json
@@ -1,0 +1,26 @@
+{
+  "comments": [
+    "This JSON file configures the Portal Networks feature of XPortal",
+    "- This list is server authoritative when connected to a host or dedicated server.",
+    "- There are a maximum of 15 networks allowed. Only Network ID's 1–15 are allowed.",
+    "- Rows with missing or empty names are ignored.",
+    "- If a configured id is removed, portals on that id are moved to Global Portal List."
+  ],
+  "networks": [
+    { "id": 1, "name": "Bosses" },
+    { "id": 2, "name": "Vendors" },
+    { "id": 3, "name": "" },
+    { "id": 4, "name": "" },
+    { "id": 5, "name": "" },
+    { "id": 6, "name": "" },
+    { "id": 7, "name": "" },
+    { "id": 8, "name": "" },
+    { "id": 9, "name": "" },
+    { "id": 10, "name": "" },
+    { "id": 11, "name": "" },
+    { "id": 12, "name": "" },
+    { "id": 13, "name": "" },
+    { "id": 14, "name": "" },
+    { "id": 15, "name": "" }
+  ]
+}


### PR DESCRIPTION
**Problem To Solve:** On densely populated servers, the server list becomes very long.  In most cases, players are looking for portals they have put down themselves, but also would like to assign portals to a Global List. Additionally, players still want the option to visit other players portals as well.

**Solution:**
### Introducing Portal Networks
This allows players to select whether they want their Portal on the Global Network, or their Player Network. Additionally, when selecting a destination portal, you can select the destination portal network, which will then filter the list to only those portals in the selected Network, making the list shorter. Alternatively, if a portal is to be shared among the server globally, this allows for the owner to decide to keep it in the Global List.  For example, I might build a small house at Haldor. I can name my portal "Vendor - Haldor" and select the Global Portals network, since the idea is that it's a shared area.

**Features:**
- Complete backwards compatibility with existing portals from earlier mod version. Puts all portals on the Global Network. Allows owners and/or admins to move their portals to their Player Network, if so desired.
- Two Networks: Global Network or Player-Specific Network
- Creator of Portal or Admin can change Portal Network on existing portals.
    - Non-Admins can NOT change the Portal Network of other players portals.
    
### Private Portals
This new feature adds to the Portal Network feature by allowing Portal Creators to set a portal as Private. Private portals can only be accessed by their creator.  Portal settings on Private portals can be adjusted by the creator or admins, but admins are also restricted from going through private destinations.

- Adds a Attribute on the Portal to denote it as a Private Portal
- Private Portals show up under the "My Private Portals"
- Portals have the option to be built defaulting to Private Portal on build. This is controlled via a BepInEx config setting called **_DefaultPrivatePortal_**, which is true by default.

### Custom Portal Networks

- Provides a server-side configuration file for creating up to 15 global networks with a custom network name.
- Default networks include "Bosses" and "Vendors", but can be changed. Server detects config changes without the need of  server restart.
- Custom Portal Networks are Server-Authoritative when clients are connected.

<img width="810" height="498" alt="image" src="https://github.com/user-attachments/assets/ddb748f1-9727-4ffc-95d0-395ce3769df7" />
