### PR TITLE
Fix portal list not loading on Valheim 1.0

### DIFF
--- a/Docs/Modules/51Changelog-current.t4
+++ b/Docs/Modules/51Changelog-current.t4
@@ -1,1 +1,2 @@
 	* Add translation to Japanese
+	* Fixed portal list not loading since Valheim update 1.0

--- a/XPortal/XPortal.cs
+++ b/XPortal/XPortal.cs
@@ -325,7 +325,7 @@ namespace XPortal
         /// <returns>A list of portal ZDOs</returns>
         private static List<ZDO> GetAllPortalZDOs()
         {
-            return ZDOMan.instance.GetPortals();
+            return ZDOMan.instance.GetPortalList();
         }
 
         /// <summary>


### PR DESCRIPTION
## Fix XPortal on Valheim 1.0

Valheim 1.0 broke XPortal on dedicated servers: clients receive the XPortal
config but never a portal list, so every portal renders as `(No Name)` with
target `(None)`.

There are **two** separate incompatibilities. Only one needs a source change.

### 1. `ZDOMan.GetPortals()` changed return type — needs the code change in this PR

Valheim 1.0 introduced a sectored save format and changed the signature:

```
XPortal 1.2.24 expects : List<ZDO> ZDOMan.GetPortals()
Valheim 1.0 provides   : Dictionary<SectorIndex, List<ZDO>> ZDOMan.GetPortals()
```

Server-side, every client sync request throws:

```
System.MissingMethodException: Method not found:
System.Collections.Generic.List`1<ZDO> .ZDOMan.GetPortals()
  at XPortal.XPortal.ProcessSyncRequest (System.String reason)
  at XPortal.RPC.Server.ServerEvents.RPC_SyncRequest (System.Int64 sender, System.String reason)
  at ZRoutedRpc.HandleRoutedRPC (ZRoutedRpc+RoutedRPCData data)
```

Valheim 1.0 also added `ZDOMan.GetPortalList()`, public, returning `List<ZDO>` —
a drop-in replacement. That is the one-line change here, in
`GetAllPortalZDOs()`.

### 2. `ZRoutedRpc.Everybody` became a `const` — needs no code change, only a rebuild

In 1.0 this changed from a static field to `const long` (field flags `0x8056` =
Public|Static|Literal|HasDefault, value `0`). Assemblies compiled against the
pre-1.0 reference emit `ldsfld`, which cannot read a literal field:

```
System.MissingFieldException: Field not found: .ZRoutedRpc.Everybody
Due to: Using static instructions with literal field
  at ServerSync.CustomSyncedValueBase.set_BoxedValue (System.Object value)
```

XPortal uses it in four places, all in `RPC/SendToClient.cs`: `SyncPortal`,
`Resync`, `Config` (broadcast) and `PingMap`. Note that the per-client
`Config(long clientPeerID, ZPackage)` overload does **not** use it — which is
exactly why config sync kept working while portal sync did not, and why the
symptom looks so odd from a user's point of view.

Recompiling against the 1.0 assemblies makes the compiler inline the constant,
so no source edit is required. Worth knowing that a rebuild alone fixes half of
this, and that it silently affects any mod carrying ServerSync too.

### Verification

I resolved every Valheim member reference the built assembly makes (80 of them)
against the Valheim 1.0 assemblies, comparing full signatures — return type and
parameter types, not just names. With this change: zero mismatches. `GetPortals`
was the only remaining one.

All ZDO keys and RPC name literals are byte-identical to the released 1.2.24
build, so storage format and wire protocol are unchanged and this interoperates
with unpatched clients:

```
XPortal_TargetId, XPortal_PreviousId, XPortal_SyncPortal, XPortal_Resync,
XPortal_SyncRequest, XPortal_AddOrUpdateRequest, XPortal_Config, tag
```

Built and tested against Valheim 1.0 with BepInEx 5.4.2350 and Jotunn 2.27.1,
on a dedicated server plus client. Portal names and destinations all returned.

### Note on stored data

No player data is lost by these bugs. Portal names live in the vanilla `tag`
ZDO field and destinations in `XPortal_TargetId`, both untouched in the world
`.db`.

There is, however, a data-loss trap while the mod is broken: with an empty
client-side list, saving a portal in the config UI sends `Target = ZDOID.None`,
and `RPC_AddOrUpdateRequest` — which never calls `GetPortals` and so keeps
running even while sync is crashing — writes that over the real destination.
Anyone who tried to re-pair portals manually will have overwritten those
targets. Might be worth a warning note when this is released.


### Included

* `XPortal/XPortal.cs` — the one-line fix.
* `Docs/Modules/51Changelog-current.t4` — a changelog bullet, since `main` is on
  unreleased v1.2.25 and v1.2.24 has already been rotated into
  `52Changelogs-previous.t4`. Drop it if you'd rather word it yourself.

I left `ModInfo.Version`, `CHANGELOG.md` and `README.md` alone — the version is
already at 1.2.25 and the markdown is generated from the T4 templates, which I
can't run here.

AI Assisted Fix.